### PR TITLE
feat: allow users to extend default rules

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -18385,6 +18385,15 @@ function parseCommand(input) {
 
 // src/evaluator.ts
 var import_os = require("os");
+function safeRegexTest(pattern, input) {
+  try {
+    return new RegExp(pattern).test(input);
+  } catch {
+    process.stderr.write(`[warden] Warning: invalid regex pattern: ${pattern}
+`);
+    return false;
+  }
+}
 function commandMatchesName(cmd, name) {
   if (name.startsWith("/")) {
     return cmd.originalCommand === name;
@@ -18394,7 +18403,11 @@ function commandMatchesName(cmd, name) {
   }
   return cmd.command === name;
 }
-function evaluate(parsed, config) {
+var MAX_RECURSION_DEPTH = 10;
+function evaluate(parsed, config, depth = 0) {
+  if (depth > MAX_RECURSION_DEPTH) {
+    return { decision: "ask", reason: "Maximum recursion depth exceeded", details: [] };
+  }
   if (parsed.parseError) {
     return { decision: "ask", reason: "Could not parse command safely", details: [] };
   }
@@ -18404,7 +18417,7 @@ function evaluate(parsed, config) {
   if (parsed.hasSubshell && parsed.subshellCommands.length > 0) {
     for (const subCmd of parsed.subshellCommands) {
       const subParsed = parseCommand(subCmd);
-      const subResult = evaluate(subParsed, config);
+      const subResult = evaluate(subParsed, config, depth + 1);
       if (subResult.decision === "deny") {
         return { decision: "deny", reason: `Subshell command: ${subResult.reason}`, details: subResult.details };
       }
@@ -18417,7 +18430,7 @@ function evaluate(parsed, config) {
   }
   const details = [];
   for (const cmd of parsed.commands) {
-    details.push(evaluateCommand(cmd, config));
+    details.push(evaluateCommand(cmd, config, depth));
   }
   const decisions = details.map((d) => d.decision);
   if (decisions.includes("deny")) {
@@ -18438,7 +18451,7 @@ function evaluate(parsed, config) {
   }
   return { decision: "allow", reason: "All commands are safe", details };
 }
-function evaluateCommand(cmd, config) {
+function evaluateCommand(cmd, config, depth = 0) {
   const { command, args: args2 } = cmd;
   for (const layer of config.layers) {
     if (layer.alwaysDeny.some((name) => commandMatchesName(cmd, name))) {
@@ -18449,28 +18462,49 @@ function evaluateCommand(cmd, config) {
     }
   }
   if ((command === "ssh" || command === "scp" || command === "rsync") && config.trustedSSHHosts?.length) {
-    const sshResult = evaluateSSHCommand(cmd, config);
+    const sshResult = evaluateSSHCommand(cmd, config, depth);
     if (sshResult) return sshResult;
   }
   if (command === "docker" && config.trustedDockerContainers?.length) {
-    const dockerResult = evaluateDockerExec(cmd, config);
+    const dockerResult = evaluateDockerExec(cmd, config, depth);
     if (dockerResult) return dockerResult;
   }
   if (command === "kubectl" && config.trustedKubectlContexts?.length) {
-    const kubectlResult = evaluateKubectlExec(cmd, config);
+    const kubectlResult = evaluateKubectlExec(cmd, config, depth);
     if (kubectlResult) return kubectlResult;
   }
   if (command === "sprite" && config.trustedSprites?.length) {
-    const spriteResult = evaluateSpriteExec(cmd, config);
+    const spriteResult = evaluateSpriteExec(cmd, config, depth);
     if (spriteResult) return spriteResult;
   }
+  const mergedRule = collectMergedRule(cmd, config);
+  if (mergedRule) {
+    return evaluateRule(cmd, mergedRule);
+  }
+  return { command, args: args2, decision: config.defaultDecision, reason: `No rule for "${command}"`, matchedRule: "default" };
+}
+function collectMergedRule(cmd, config) {
+  const matchingRules = [];
   for (const layer of config.layers) {
     const rule = layer.rules.find((r) => commandMatchesName(cmd, r.command));
     if (rule) {
-      return evaluateRule(cmd, rule);
+      matchingRules.push(rule);
+      if (rule.override) break;
     }
   }
-  return { command, args: args2, decision: config.defaultDecision, reason: `No rule for "${command}"`, matchedRule: "default" };
+  if (matchingRules.length === 0) return null;
+  if (matchingRules.length === 1) return matchingRules[0];
+  const mergedPatterns = [];
+  for (const rule of matchingRules) {
+    if (rule.argPatterns) {
+      mergedPatterns.push(...rule.argPatterns);
+    }
+  }
+  return {
+    command: matchingRules[0].command,
+    default: matchingRules[0].default,
+    argPatterns: mergedPatterns
+  };
 }
 function evaluateRule(cmd, rule) {
   const { command, args: args2 } = cmd;
@@ -18482,10 +18516,10 @@ function evaluateRule(cmd, rule) {
       matched = matched && m.noArgs === (args2.length === 0);
     }
     if (m.argsMatch && matched) {
-      matched = m.argsMatch.some((re) => new RegExp(re).test(argsJoined));
+      matched = m.argsMatch.some((re) => safeRegexTest(re, argsJoined));
     }
     if (m.anyArgMatches && matched) {
-      matched = args2.some((arg) => m.anyArgMatches.some((re) => new RegExp(re).test(arg)));
+      matched = args2.some((arg) => m.anyArgMatches.some((re) => safeRegexTest(re, arg)));
     }
     if (m.argCount && matched) {
       if (m.argCount.min !== void 0) matched = matched && args2.length >= m.argCount.min;
@@ -18604,7 +18638,7 @@ function parseSSHArgs(args2) {
   }
   return {
     host,
-    remoteCommand: remoteArgs.length > 0 ? remoteArgs.join(" ") : null
+    remoteCommand: remoteArgs.length > 0 ? remoteArgs.map(shellQuote).join(" ") : null
   };
 }
 function extractHostFromRemotePath(args2) {
@@ -18614,7 +18648,7 @@ function extractHostFromRemotePath(args2) {
   }
   return null;
 }
-function evaluateSSHCommand(cmd, config) {
+function evaluateSSHCommand(cmd, config, depth = 0) {
   const { command, args: args2 } = cmd;
   const trustedHosts = config.trustedSSHHosts || [];
   if (command === "scp" || command === "rsync") {
@@ -18622,6 +18656,24 @@ function evaluateSSHCommand(cmd, config) {
     if (!host2) return null;
     const target2 = findMatchingTarget(host2, trustedHosts);
     if (!target2) return null;
+    if (target2.allowAll || !target2.overrides) {
+      return {
+        command,
+        args: args2,
+        decision: "allow",
+        reason: `Trusted SSH host "${host2}"${target2.allowAll ? " (allowAll)" : ""}`,
+        matchedRule: "trustedSSHHosts"
+      };
+    }
+    if (target2.overrides.alwaysDeny.some((name) => name === command)) {
+      return {
+        command,
+        args: args2,
+        decision: "deny",
+        reason: `Trusted SSH host "${host2}": "${command}" blocked by overrides`,
+        matchedRule: "trustedSSHHosts"
+      };
+    }
     return {
       command,
       args: args2,
@@ -18653,7 +18705,7 @@ function evaluateSSHCommand(cmd, config) {
     };
   }
   const parsed = parseCommand(remoteCommand);
-  const result = evaluate(parsed, configWithContextOverrides(config, target));
+  const result = evaluate(parsed, configWithContextOverrides(config, target), depth + 1);
   return {
     command,
     args: args2,
@@ -18673,6 +18725,12 @@ var DOCKER_EXEC_FLAGS_WITH_VALUE = /* @__PURE__ */ new Set([
   "--detach-keys"
 ]);
 var INTERACTIVE_SHELLS = /* @__PURE__ */ new Set(["bash", "sh", "zsh"]);
+function shellQuote(arg) {
+  if (/[\s"'\\$`!#&|;()<>]/.test(arg)) {
+    return `'${arg.replace(/'/g, "'\\''")}'`;
+  }
+  return arg;
+}
 function configWithContextOverrides(config, target) {
   const overrideLayers = [];
   if (target?.overrides) overrideLayers.push(target.overrides);
@@ -18683,7 +18741,7 @@ function configWithContextOverrides(config, target) {
     layers: [...overrideLayers, ...config.layers]
   };
 }
-function evaluateRemoteCommand(remoteArgs, config, target) {
+function evaluateRemoteCommand(remoteArgs, config, target, depth = 0) {
   if (target?.allowAll) {
     return { decision: "allow", reason: "allowAll target", details: [] };
   }
@@ -18698,7 +18756,7 @@ function evaluateRemoteCommand(remoteArgs, config, target) {
   if (INTERACTIVE_SHELLS.has(remoteCmd) && remoteArgs[1] === "-c" && remoteArgs.length >= 3) {
     const innerCommand = remoteArgs.slice(2).join(" ");
     const parsed2 = parseCommand(innerCommand);
-    return evaluate(parsed2, overriddenConfig);
+    return evaluate(parsed2, overriddenConfig, depth + 1);
   }
   const parsed = {
     commands: [{ command: remoteCmd, originalCommand: remoteCmd, args: remoteArgs.slice(1), envPrefixes: [], raw: remoteArgs.join(" ") }],
@@ -18706,7 +18764,7 @@ function evaluateRemoteCommand(remoteArgs, config, target) {
     subshellCommands: [],
     parseError: false
   };
-  return evaluate(parsed, overriddenConfig);
+  return evaluate(parsed, overriddenConfig, depth + 1);
 }
 function parseDockerExecArgs(args2) {
   let target = null;
@@ -18735,14 +18793,14 @@ function parseDockerExecArgs(args2) {
   }
   return { target, remoteArgs };
 }
-function evaluateDockerExec(cmd, config) {
+function evaluateDockerExec(cmd, config, depth = 0) {
   const { command, args: args2 } = cmd;
   if (args2[0] !== "exec") return null;
   const { target: containerName, remoteArgs } = parseDockerExecArgs(args2.slice(1));
   if (!containerName) return null;
   const matched = findMatchingTarget(containerName, config.trustedDockerContainers || []);
   if (!matched) return null;
-  const result = evaluateRemoteCommand(remoteArgs, config, matched);
+  const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);
   return {
     command,
     args: args2,
@@ -18815,14 +18873,14 @@ function parseKubectlExecArgs(args2) {
   }
   return { context, pod, remoteArgs };
 }
-function evaluateKubectlExec(cmd, config) {
+function evaluateKubectlExec(cmd, config, depth = 0) {
   const { command, args: args2 } = cmd;
   if (args2[0] !== "exec") return null;
   const { context, pod, remoteArgs } = parseKubectlExecArgs(args2.slice(1));
   if (!context) return null;
   const matched = findMatchingTarget(context, config.trustedKubectlContexts || []);
   if (!matched) return null;
-  const result = evaluateRemoteCommand(remoteArgs, config, matched);
+  const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);
   return {
     command,
     args: args2,
@@ -18882,13 +18940,13 @@ function parseSpriteExecArgs(args2) {
   }
   return { spriteName, remoteArgs };
 }
-function evaluateSpriteExec(cmd, config) {
+function evaluateSpriteExec(cmd, config, depth = 0) {
   const { command, args: args2 } = cmd;
   const { spriteName, remoteArgs } = parseSpriteExecArgs(args2);
   if (!spriteName) return null;
   const matched = findMatchingTarget(spriteName, config.trustedSprites || []);
   if (!matched) return null;
-  const result = evaluateRemoteCommand(remoteArgs, config, matched);
+  const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);
   return {
     command,
     args: args2,
@@ -19604,6 +19662,10 @@ var DEFAULT_CONFIG = {
 };
 
 // src/rules.ts
+var VALID_DECISIONS = /* @__PURE__ */ new Set(["allow", "deny", "ask"]);
+function isValidDecision(value) {
+  return VALID_DECISIONS.has(value);
+}
 var USER_CONFIG_PATHS = [
   (0, import_path2.join)((0, import_os2.homedir)(), ".claude", "warden.yaml"),
   (0, import_path2.join)((0, import_os2.homedir)(), ".claude", "warden.json")
@@ -19654,15 +19716,36 @@ function tryLoadFile(filePath) {
     if (parsed && typeof parsed === "object") {
       return parsed;
     }
-  } catch {
+  } catch (err) {
+    process.stderr.write(`[warden] Warning: failed to parse config ${filePath}: ${err instanceof Error ? err.message : String(err)}
+`);
   }
   return null;
 }
 function extractLayer(raw) {
+  const rules = Array.isArray(raw.rules) ? raw.rules : [];
+  for (const rule of rules) {
+    if (rule && typeof rule === "object") {
+      if (rule.default && !isValidDecision(rule.default)) {
+        process.stderr.write(`[warden] Warning: invalid rule default "${rule.default}" for "${rule.command}", using "ask"
+`);
+        rule.default = "ask";
+      }
+      if (Array.isArray(rule.argPatterns)) {
+        for (const pattern of rule.argPatterns) {
+          if (pattern?.decision && !isValidDecision(pattern.decision)) {
+            process.stderr.write(`[warden] Warning: invalid pattern decision "${pattern.decision}" for "${rule.command}", using "ask"
+`);
+            pattern.decision = "ask";
+          }
+        }
+      }
+    }
+  }
   return {
     alwaysAllow: Array.isArray(raw.alwaysAllow) ? raw.alwaysAllow : [],
     alwaysDeny: Array.isArray(raw.alwaysDeny) ? raw.alwaysDeny : [],
-    rules: Array.isArray(raw.rules) ? raw.rules : []
+    rules
   };
 }
 function parseTrustedList(raw) {
@@ -19694,7 +19777,12 @@ function mergeNonLayerFields(config, raw) {
     config.trustedSprites = [...config.trustedSprites || [], ...parseTrustedList(raw.trustedSprites)];
   }
   if (typeof raw.defaultDecision === "string") {
-    config.defaultDecision = raw.defaultDecision;
+    if (isValidDecision(raw.defaultDecision)) {
+      config.defaultDecision = raw.defaultDecision;
+    } else {
+      process.stderr.write(`[warden] Warning: invalid defaultDecision "${raw.defaultDecision}", ignoring
+`);
+    }
   }
   if (typeof raw.askOnSubshell === "boolean") {
     config.askOnSubshell = raw.askOnSubshell;
@@ -19850,10 +19938,22 @@ function sendNotification(title, message, config) {
 }
 
 // src/index.ts
+var MAX_STDIN_SIZE = 1024 * 1024;
 async function main() {
   let raw = "";
   for await (const chunk of process.stdin) {
     raw += chunk;
+    if (raw.length > MAX_STDIN_SIZE) {
+      const output2 = {
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "ask",
+          permissionDecisionReason: "[warden] Input exceeds size limit"
+        }
+      };
+      process.stdout.write(JSON.stringify(output2));
+      process.exit(0);
+    }
   }
   let input;
   try {

--- a/src/__tests__/evaluator.test.ts
+++ b/src/__tests__/evaluator.test.ts
@@ -242,11 +242,11 @@ describe('evaluator', () => {
       expect(evaluate(parseCommand('curl https://example.com'), config).decision).toBe('deny');
     });
 
-    it('workspace rule overrides default rule for same command', () => {
+    it('workspace rule with override replaces default rule for same command', () => {
       const workspaceLayer: ConfigLayer = {
         alwaysAllow: [],
         alwaysDeny: [],
-        rules: [{ command: 'npm', default: 'deny' }],
+        rules: [{ command: 'npm', default: 'deny', override: true }],
       };
       const config: WardenConfig = {
         ...structuredClone(DEFAULT_CONFIG),
@@ -255,11 +255,11 @@ describe('evaluator', () => {
       expect(evaluate(parseCommand('npm install'), config).decision).toBe('deny');
     });
 
-    it('user rule overrides default rule', () => {
+    it('user rule with override replaces default rule', () => {
       const userLayer: ConfigLayer = {
         alwaysAllow: [],
         alwaysDeny: [],
-        rules: [{ command: 'docker', default: 'allow' }],
+        rules: [{ command: 'docker', default: 'allow', override: true }],
       };
       const config: WardenConfig = {
         ...structuredClone(DEFAULT_CONFIG),
@@ -268,7 +268,7 @@ describe('evaluator', () => {
       expect(evaluate(parseCommand('docker run ubuntu'), config).decision).toBe('allow');
     });
 
-    it('first layer with matching rule wins (workspace over user)', () => {
+    it('first layer default wins when merging (workspace over user)', () => {
       const userLayer: ConfigLayer = {
         alwaysAllow: [],
         alwaysDeny: [],
@@ -283,7 +283,9 @@ describe('evaluator', () => {
         ...structuredClone(DEFAULT_CONFIG),
         layers: [workspaceLayer, userLayer, DEFAULT_CONFIG.layers[0]],
       };
-      expect(evaluate(parseCommand('npm install'), config).decision).toBe('ask');
+      // npm install matches a default argPattern → allow; but unmatched commands use workspace's default: ask
+      expect(evaluate(parseCommand('npm install'), config).decision).toBe('allow');
+      expect(evaluate(parseCommand('npm some-unknown-cmd'), config).decision).toBe('ask');
     });
   });
 

--- a/src/__tests__/rule-merge.test.ts
+++ b/src/__tests__/rule-merge.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from 'vitest';
+import { evaluate } from '../evaluator';
+import { parseCommand } from '../parser';
+import { DEFAULT_CONFIG } from '../defaults';
+import type { WardenConfig, ConfigLayer } from '../types';
+
+function emptyLayer(overrides: Partial<ConfigLayer> = {}): ConfigLayer {
+  return { alwaysAllow: [], alwaysDeny: [], rules: [], ...overrides };
+}
+
+function evalWith(cmd: string, overrides: Partial<WardenConfig>) {
+  const config: WardenConfig = { ...structuredClone(DEFAULT_CONFIG), ...overrides };
+  return evaluate(parseCommand(cmd), config);
+}
+
+describe('rule merging across layers', () => {
+  it('user rule extends default rule by default', () => {
+    const userLayer = emptyLayer({
+      rules: [{
+        command: 'npx',
+        default: 'ask',
+        argPatterns: [{
+          match: { anyArgMatches: ['^clawhub$'] },
+          decision: 'allow',
+          description: 'user pattern',
+        }],
+      }],
+    });
+
+    const result = evalWith('npx clawhub', {
+      layers: [userLayer, ...DEFAULT_CONFIG.layers],
+    });
+    expect(result.decision).toBe('allow');
+
+    // Default npx patterns should still work (e.g. vitest is allowed by default)
+    const result2 = evalWith('npx vitest', {
+      layers: [userLayer, ...DEFAULT_CONFIG.layers],
+    });
+    expect(result2.decision).toBe('allow');
+  });
+
+  it('user default field overrides lower-layer default', () => {
+    const userLayer = emptyLayer({
+      rules: [{
+        command: 'npx',
+        default: 'deny',
+        argPatterns: [{
+          match: { anyArgMatches: ['^clawhub$'] },
+          decision: 'allow',
+        }],
+      }],
+    });
+
+    // clawhub matches user pattern → allow
+    const r1 = evalWith('npx clawhub', {
+      layers: [userLayer, ...DEFAULT_CONFIG.layers],
+    });
+    expect(r1.decision).toBe('allow');
+
+    // unknown-tool doesn't match any pattern → user's default: deny
+    const r2 = evalWith('npx unknown-tool-xyz', {
+      layers: [userLayer, ...DEFAULT_CONFIG.layers],
+    });
+    expect(r2.decision).toBe('deny');
+  });
+
+  it('override: true stops merging — shadows lower layers', () => {
+    const userLayer = emptyLayer({
+      rules: [{
+        command: 'npx',
+        override: true,
+        default: 'deny',
+        argPatterns: [{
+          match: { anyArgMatches: ['^clawhub$'] },
+          decision: 'allow',
+        }],
+      }],
+    });
+
+    // clawhub → allow (user pattern)
+    const r1 = evalWith('npx clawhub', {
+      layers: [userLayer, ...DEFAULT_CONFIG.layers],
+    });
+    expect(r1.decision).toBe('allow');
+
+    // vitest would normally be allowed by default rules, but override stops merging
+    const r2 = evalWith('npx vitest', {
+      layers: [userLayer, ...DEFAULT_CONFIG.layers],
+    });
+    expect(r2.decision).toBe('deny');
+  });
+
+  it('3-layer merge: workspace + user + default', () => {
+    const workspaceLayer = emptyLayer({
+      rules: [{
+        command: 'npx',
+        default: 'ask',
+        argPatterns: [{
+          match: { anyArgMatches: ['^ws-tool$'] },
+          decision: 'allow',
+          description: 'workspace pattern',
+        }],
+      }],
+    });
+
+    const userLayer = emptyLayer({
+      rules: [{
+        command: 'npx',
+        default: 'ask',
+        argPatterns: [{
+          match: { anyArgMatches: ['^user-tool$'] },
+          decision: 'allow',
+          description: 'user pattern',
+        }],
+      }],
+    });
+
+    const layers = [workspaceLayer, userLayer, ...DEFAULT_CONFIG.layers];
+
+    // workspace pattern
+    expect(evalWith('npx ws-tool', { layers }).decision).toBe('allow');
+    // user pattern
+    expect(evalWith('npx user-tool', { layers }).decision).toBe('allow');
+    // default pattern (e.g. vitest)
+    expect(evalWith('npx vitest', { layers }).decision).toBe('allow');
+  });
+
+  it('3-layer merge: workspace override stops at workspace', () => {
+    const workspaceLayer = emptyLayer({
+      rules: [{
+        command: 'npx',
+        override: true,
+        default: 'deny',
+        argPatterns: [{
+          match: { anyArgMatches: ['^ws-only$'] },
+          decision: 'allow',
+        }],
+      }],
+    });
+
+    const userLayer = emptyLayer({
+      rules: [{
+        command: 'npx',
+        default: 'ask',
+        argPatterns: [{
+          match: { anyArgMatches: ['^user-tool$'] },
+          decision: 'allow',
+        }],
+      }],
+    });
+
+    const layers = [workspaceLayer, userLayer, ...DEFAULT_CONFIG.layers];
+
+    expect(evalWith('npx ws-only', { layers }).decision).toBe('allow');
+    // user-tool and vitest are blocked because workspace has override: true
+    expect(evalWith('npx user-tool', { layers }).decision).toBe('deny');
+    expect(evalWith('npx vitest', { layers }).decision).toBe('deny');
+  });
+
+  it('no regression: single-layer rules still work identically', () => {
+    // Just using DEFAULT_CONFIG — no user layers
+    const r1 = evaluate(parseCommand('npx vitest'), DEFAULT_CONFIG);
+    expect(r1.decision).toBe('allow');
+
+    const r2 = evaluate(parseCommand('npx unknown-xyz'), DEFAULT_CONFIG);
+    expect(r2.decision).toBe('ask');
+
+    const r3 = evaluate(parseCommand('git status'), DEFAULT_CONFIG);
+    expect(r3.decision).toBe('allow');
+  });
+
+  it('user rule for command not in defaults works standalone', () => {
+    const userLayer = emptyLayer({
+      rules: [{
+        command: 'my-custom-tool',
+        default: 'deny',
+        argPatterns: [{
+          match: { anyArgMatches: ['^safe-arg$'] },
+          decision: 'allow',
+        }],
+      }],
+    });
+
+    const layers = [userLayer, ...DEFAULT_CONFIG.layers];
+
+    expect(evalWith('my-custom-tool safe-arg', { layers }).decision).toBe('allow');
+    expect(evalWith('my-custom-tool danger', { layers }).decision).toBe('deny');
+  });
+
+  it('user layer without argPatterns still merges with default patterns', () => {
+    const userLayer = emptyLayer({
+      rules: [{
+        command: 'npx',
+        default: 'deny',
+        // No argPatterns — just overriding the default decision
+      }],
+    });
+
+    const layers = [userLayer, ...DEFAULT_CONFIG.layers];
+
+    // vitest still allowed via default layer's patterns
+    expect(evalWith('npx vitest', { layers }).decision).toBe('allow');
+    // But unmatched commands now get user's default: deny
+    expect(evalWith('npx unknown-xyz', { layers }).decision).toBe('deny');
+  });
+});

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -122,16 +122,48 @@ function evaluateCommand(cmd: ParsedCommand, config: WardenConfig, depth: number
     if (spriteResult) return spriteResult;
   }
 
-  // 3. Scoped command rules (first layer with a matching rule wins)
-  for (const layer of config.layers) {
-    const rule = layer.rules.find(r => commandMatchesName(cmd, r.command));
-    if (rule) {
-      return evaluateRule(cmd, rule);
-    }
+  // 3. Scoped command rules — collect and merge across layers
+  const mergedRule = collectMergedRule(cmd, config);
+  if (mergedRule) {
+    return evaluateRule(cmd, mergedRule);
   }
 
   // 4. Default
   return { command, args, decision: config.defaultDecision, reason: `No rule for "${command}"`, matchedRule: 'default' };
+}
+
+/**
+ * Collect matching rules across all layers and merge them.
+ * Rules are merged by concatenating argPatterns in layer priority order.
+ * The `default` decision comes from the highest-priority layer that defines a rule.
+ * If any rule has `override: true`, stop collecting from lower layers.
+ */
+function collectMergedRule(cmd: ParsedCommand, config: WardenConfig): CommandRule | null {
+  const matchingRules: CommandRule[] = [];
+
+  for (const layer of config.layers) {
+    const rule = layer.rules.find(r => commandMatchesName(cmd, r.command));
+    if (rule) {
+      matchingRules.push(rule);
+      if (rule.override) break;
+    }
+  }
+
+  if (matchingRules.length === 0) return null;
+  if (matchingRules.length === 1) return matchingRules[0];
+
+  const mergedPatterns: CommandRule['argPatterns'] = [];
+  for (const rule of matchingRules) {
+    if (rule.argPatterns) {
+      mergedPatterns.push(...rule.argPatterns);
+    }
+  }
+
+  return {
+    command: matchingRules[0].command,
+    default: matchingRules[0].default,
+    argPatterns: mergedPatterns,
+  };
 }
 
 function evaluateRule(cmd: ParsedCommand, rule: CommandRule): CommandEvalDetail {

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,8 @@ export interface CommandRule {
   command: string;
   default: Decision;
   argPatterns?: ArgPattern[];
+  /** When true, this rule completely replaces lower-layer rules instead of merging with them. */
+  override?: boolean;
 }
 
 export interface ConfigLayer {


### PR DESCRIPTION
## Summary

- User/workspace rules now **merge** with default rules by default — argPatterns are prepended so user patterns match first, but built-in safe patterns still apply as fallback
- Added `override?: boolean` to `CommandRule` — set `override: true` to explicitly replace a default rule (previous shadow behavior)
- Highest-priority layer's `default` decision is used when no pattern matches

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` passes (all 367 tests)
- [x] `pnpm run build` succeeds
- [x] New tests cover: extend, override, 3-layer merge, no-regression scenarios

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)