### PR TITLE
feat: warn on misconfigured argPatterns referencing other commands

### DIFF
--- a/config/warden.default.yaml
+++ b/config/warden.default.yaml
@@ -86,9 +86,36 @@ notifyOnDeny: true
 
 # Command-specific rules (override built-in rules by command name).
 # The first scope (project > user > default) with a rule for a given command wins.
+#
+# IMPORTANT: Rules are matched by the command being executed, not by arguments.
+# For example, when Claude runs `python -c "import foo"`, warden looks up rules
+# for command: "python" — NOT "bash" or "sh". A common mistake is writing rules
+# for "bash" with argPatterns matching "python"; this won't work because warden
+# sees the command as "python".
+#
 # rules:
+#   # Allow all python commands
+#   - command: python
+#     default: allow
+#
+#   # Allow python -c but ask for other python usage
+#   - command: python
+#     default: ask
+#     argPatterns:
+#       - match:
+#           anyArgMatches: ['^-c$']
+#         decision: allow
+#         description: Allow python -c inline scripts
+#
+#   # Allow all node.js execution
+#   - command: node
+#     default: allow
+#
+#   # Trust all npx in this project
 #   - command: npx
-#     default: allow          # Trust all npx in this project
+#     default: allow
+#
+#   # Docker with selective allow
 #   - command: docker
 #     default: ask
 #     argPatterns:

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -19980,6 +19980,35 @@ function tryLoadFile(filePath) {
   }
   return null;
 }
+var KNOWN_COMMANDS = /* @__PURE__ */ new Set([
+  ...DEFAULT_CONFIG.layers[0].alwaysAllow,
+  ...DEFAULT_CONFIG.layers[0].alwaysDeny,
+  ...DEFAULT_CONFIG.layers[0].rules.map((r) => r.command)
+]);
+function warnArgPatternCommandMismatch(rule) {
+  if (!Array.isArray(rule.argPatterns)) return;
+  for (const pattern of rule.argPatterns) {
+    const matchers = [
+      ...pattern.match?.anyArgMatches || [],
+      ...pattern.match?.argsMatch || []
+    ];
+    for (const m of matchers) {
+      const literals = extractLiteralsFromPattern(m);
+      for (const lit of literals) {
+        if (lit !== rule.command && KNOWN_COMMANDS.has(lit)) {
+          process.stderr.write(
+            `[warden] Warning: rule for "${rule.command}" has argPattern matching "${lit}" \u2014 this won't work as expected. Rules are matched by the command being run, not its arguments. If you want to control "${lit}", add a separate rule with command: "${lit}".
+`
+          );
+        }
+      }
+    }
+  }
+}
+function extractLiteralsFromPattern(pattern) {
+  let cleaned = pattern.replace(/^\^?\(?(.*?)\)?\$?$/, "$1");
+  return cleaned.split("|").map((s) => s.trim()).filter((s) => /^[a-z][a-z0-9_-]*$/i.test(s));
+}
 function extractLayer(raw) {
   const rules = Array.isArray(raw.rules) ? raw.rules : [];
   for (const rule of rules) {
@@ -19998,6 +20027,7 @@ function extractLayer(raw) {
           }
         }
       }
+      warnArgPatternCommandMismatch(rule);
     }
   }
   return {

--- a/src/__tests__/rule-merge.test.ts
+++ b/src/__tests__/rule-merge.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { evaluate } from '../evaluator';
 import { parseCommand } from '../parser';
+import { loadConfig } from '../rules';
 import { DEFAULT_CONFIG } from '../defaults';
 import type { WardenConfig, ConfigLayer } from '../types';
 
@@ -202,5 +203,67 @@ describe('rule merging across layers', () => {
     expect(evalWith('npx vitest', { layers }).decision).toBe('allow');
     // But unmatched commands now get user's default: deny
     expect(evalWith('npx unknown-xyz', { layers }).decision).toBe('deny');
+  });
+});
+
+describe('config validation warnings', () => {
+  it('warns when argPatterns reference another known command name', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    const fs = require('fs');
+    const tmpDir = '/tmp/warden-test-validation';
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.mkdirSync(`${tmpDir}/.claude`, { recursive: true });
+    fs.writeFileSync(`${tmpDir}/.claude/warden.yaml`, `
+rules:
+  - command: bash
+    default: ask
+    argPatterns:
+      - match:
+          anyArgMatches: ['python']
+        decision: allow
+`);
+
+    loadConfig(tmpDir);
+
+    const warnings = stderrSpy.mock.calls
+      .map(c => String(c[0]))
+      .filter(msg => msg.includes('rule for "bash"') && msg.includes('matching "python"'));
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('command: "python"');
+
+    stderrSpy.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('does not warn for legitimate argPatterns', () => {
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    const fs = require('fs');
+    const tmpDir = '/tmp/warden-test-validation-ok';
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.mkdirSync(`${tmpDir}/.claude`, { recursive: true });
+    fs.writeFileSync(`${tmpDir}/.claude/warden.yaml`, `
+rules:
+  - command: python
+    default: ask
+    argPatterns:
+      - match:
+          anyArgMatches: ['^-c$']
+        decision: allow
+`);
+
+    loadConfig(tmpDir);
+
+    // Should not warn about python rule matching -c (not a command name)
+    const warnings = stderrSpy.mock.calls
+      .map(c => String(c[0]))
+      .filter(msg => msg.includes('rule for "python"') && msg.includes("won't work as expected"));
+
+    expect(warnings).toHaveLength(0);
+
+    stderrSpy.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 });

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -2,7 +2,7 @@ import { readFileSync, existsSync } from 'fs';
 import { parse as parseYaml } from 'yaml';
 import { homedir } from 'os';
 import { join } from 'path';
-import type { WardenConfig, ConfigLayer, TrustedTarget } from './types';
+import type { WardenConfig, ConfigLayer, CommandRule, TrustedTarget } from './types';
 import { DEFAULT_CONFIG } from './defaults';
 
 const VALID_DECISIONS = new Set(['allow', 'deny', 'ask']);
@@ -80,6 +80,50 @@ function tryLoadFile(filePath: string): Record<string, unknown> | null {
   return null;
 }
 
+/** Known command names from default config (used for misconfiguration detection) */
+const KNOWN_COMMANDS = new Set([
+  ...DEFAULT_CONFIG.layers[0].alwaysAllow,
+  ...DEFAULT_CONFIG.layers[0].alwaysDeny,
+  ...DEFAULT_CONFIG.layers[0].rules.map(r => r.command),
+]);
+
+/**
+ * Detect likely misconfiguration where argPatterns on one command
+ * seem to reference another command name (e.g. argPatterns on "bash"
+ * matching "python"). This is a common user mistake — rules must
+ * target the actual command being invoked.
+ */
+function warnArgPatternCommandMismatch(rule: CommandRule): void {
+  if (!Array.isArray(rule.argPatterns)) return;
+
+  for (const pattern of rule.argPatterns) {
+    const matchers = [
+      ...(pattern.match?.anyArgMatches || []),
+      ...(pattern.match?.argsMatch || []),
+    ];
+    for (const m of matchers) {
+      // Extract literal command names from simple patterns like 'python', '^python$', '^(python|node)$'
+      const literals = extractLiteralsFromPattern(m);
+      for (const lit of literals) {
+        if (lit !== rule.command && KNOWN_COMMANDS.has(lit)) {
+          process.stderr.write(
+            `[warden] Warning: rule for "${rule.command}" has argPattern matching "${lit}" — ` +
+            `this won't work as expected. Rules are matched by the command being run, not its arguments. ` +
+            `If you want to control "${lit}", add a separate rule with command: "${lit}".\n`
+          );
+        }
+      }
+    }
+  }
+}
+
+function extractLiteralsFromPattern(pattern: string): string[] {
+  // Strip common regex anchors/grouping
+  let cleaned = pattern.replace(/^\^?\(?(.*?)\)?\$?$/, '$1');
+  // Split on | for alternation groups
+  return cleaned.split('|').map(s => s.trim()).filter(s => /^[a-z][a-z0-9_-]*$/i.test(s));
+}
+
 function extractLayer(raw: Record<string, unknown>): ConfigLayer {
   const rules = Array.isArray(raw.rules) ? raw.rules : [];
   for (const rule of rules) {
@@ -96,6 +140,7 @@ function extractLayer(raw: Record<string, unknown>): ConfigLayer {
           }
         }
       }
+      warnArgPatternCommandMismatch(rule);
     }
   }
   return {


### PR DESCRIPTION
## Summary
- Adds config validation warning when argPatterns on one command reference another known command name (e.g., `bash` rule matching `python`) — a common user mistake surfaced in #29
- Adds clearer examples in reference config (`warden.default.yaml`) showing how to properly allow `python`, `node`, etc.
- Adds tests for the validation warning

Closes #29

## Test plan
- [x] All 749 tests pass
- [x] Typecheck passes
- [x] Build succeeds
- [ ] Verify warning appears with misconfigured `warden.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)