### PR TITLE
fix: update plugin install name to warden@claude-warden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Features
 - Add Codex execpolicy rules exporter (ca27d83)
 - Add session-scoped YOLO mode for temporary auto-allow with configurable duration (b7c8d11)
-- New `/claude-warden:yolo` slash command to activate/deactivate YOLO mode
+- New `/warden:yolo` slash command to activate/deactivate YOLO mode
 - YOLO hint shown on ask decisions for discoverability
 - Always-deny commands remain blocked even in YOLO mode for safety
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Two commands inside Claude Code:
 
 ```
 /plugin marketplace add banyudu/claude-warden
-/plugin install claude-warden@claude-warden
+/plugin install warden@claude-warden
 ```
 
 That's it. Restart Claude Code and Warden is active.

--- a/docs-src/src/components/Hero.tsx
+++ b/docs-src/src/components/Hero.tsx
@@ -48,7 +48,7 @@ export function Hero() {
   }, [showDecision])
 
   const copyInstall = useCallback(() => {
-    navigator.clipboard.writeText('claude plugin install claude-warden@claude-warden')
+    navigator.clipboard.writeText('claude plugin install warden@claude-warden')
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }, [])
@@ -199,7 +199,7 @@ export function Hero() {
           }}
         >
           <span style={{ color: 'var(--text-muted)' }}>$</span>
-          claude plugin install claude-warden@claude-warden
+          claude plugin install warden@claude-warden
           <span style={{ color: copied ? 'var(--color-allow)' : 'var(--text-muted)', fontSize: 12, minWidth: 40 }}>
             {copied ? 'Copied!' : 'Copy'}
           </span>

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "release:minor": "scripts/release.sh minor",
     "release:major": "scripts/release.sh major",
     "prepublishOnly": "pnpm run sync-plugin-version && pnpm run build && pnpm run test",
-    "postpublish": "claude plugin update claude-warden@local 2>/dev/null; claude plugin update claude-warden@claude-warden 2>/dev/null; echo 'Plugin caches updated'",
+    "postpublish": "claude plugin update claude-warden@local 2>/dev/null; claude plugin update warden@claude-warden 2>/dev/null; echo 'Plugin caches updated'",
     "docs:dev": "cd docs-src && pnpm dev",
     "docs:build": "cd docs-src && pnpm install && pnpm build"
   },


### PR DESCRIPTION
## Summary
- Update all references from `claude-warden@claude-warden` to `warden@claude-warden` (the correct plugin@marketplace format after the v2.0.0 rename)
- Fix slash command reference in CHANGELOG from `/claude-warden:yolo` to `/warden:yolo`

## Files changed
- `README.md` — install command
- `package.json` — postpublish script
- `docs-src/src/components/Hero.tsx` — clipboard copy and display text
- `CHANGELOG.md` — slash command name

## Test plan
- [ ] Verify `warden@claude-warden` is the correct install identifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)