### PR TITLE
fix: recursively parse sh/bash/zsh -c in xargs evaluator

### DIFF
--- a/src/__tests__/evaluator.test.ts
+++ b/src/__tests__/evaluator.test.ts
@@ -783,6 +783,9 @@ describe('evaluator', () => {
     it('allows xargs with no args (defaults to echo)', () => expect(eval_('xargs').decision).toBe('allow'));
     it('allows xargs with options and no command (defaults to echo)', () => expect(eval_('xargs -0').decision).toBe('allow'));
     it('asks when xargs subcommand cannot be resolved', () => expect(eval_('xargs --unknown').decision).toBe('ask'));
+    it('allows xargs with sh -c when inner commands are safe', () => expect(eval_("xargs -I {} sh -c 'echo === && head -50 foo'").decision).toBe('allow'));
+    it('allows xargs with bash -c when inner commands are safe', () => expect(eval_("xargs -I {} bash -c 'echo hello && ls'").decision).toBe('allow'));
+    it('denies xargs with sh -c when inner command is denied', () => expect(eval_("xargs sh -c 'sudo rm -rf /'").decision).toBe('deny'));
 
     // tee
     it('allows tee to normal path', () => expect(eval_('tee output.txt').decision).toBe('allow'));

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -335,12 +335,24 @@ function evaluateXargsCommand(cmd: ParsedCommand, config: WardenConfig, depth: n
     };
   }
 
-  const parsed: ParseResult = {
-    commands: [subcommand],
-    hasSubshell: false,
-    subshellCommands: [],
-    parseError: false,
-  };
+  // Handle sh/bash/zsh -c "..." — recursively parse inner command
+  const isShellExec =
+    (subcommand.command === 'sh' || subcommand.command === 'bash' || subcommand.command === 'zsh') &&
+    subcommand.args.length >= 2 &&
+    subcommand.args[0] === '-c';
+
+  let parsed: ParseResult;
+  if (isShellExec) {
+    const innerResult = parseCommand(subcommand.args[1]);
+    if (innerResult.parseError) {
+      parsed = { commands: [subcommand], hasSubshell: false, subshellCommands: [], parseError: false };
+    } else {
+      parsed = innerResult;
+    }
+  } else {
+    parsed = { commands: [subcommand], hasSubshell: false, subshellCommands: [], parseError: false };
+  }
+
   const result = evaluate(parsed, config, depth + 1);
 
   return {


### PR DESCRIPTION
## Summary
- Fix xargs evaluator to recursively parse `sh -c`/`bash -c`/`zsh -c` subcommands instead of evaluating the shell binary directly
- Adds 3 test cases for xargs + shell -c combinations

Fixes #42

## Test plan
- [x] Existing xargs tests pass
- [x] New tests: `xargs -I {} sh -c 'echo ... && head ...'` → allow
- [x] New tests: `xargs -I {} bash -c 'echo hello && ls'` → allow
- [x] New tests: `xargs sh -c 'sudo rm -rf /'` → deny

🤖 Generated with [Claude Code](https://claude.com/claude-code)