### PR TITLE
feat: allow read-only claude plugin commands by default

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -19614,7 +19614,8 @@ var DEFAULT_CONFIG = {
         command: "claude",
         default: "ask",
         argPatterns: [
-          { match: { anyArgMatches: ["^--(version|help)$", "^-[vh]$"] }, decision: "allow", description: "Version/help flags" }
+          { match: { anyArgMatches: ["^--(version|help)$", "^-[vh]$"] }, decision: "allow", description: "Version/help flags" },
+          { match: { argsMatch: ["^plugin(s)?\\s+(list|help|validate|marketplace\\s+(list|help))\\b"] }, decision: "allow", description: "Read-only plugin commands" }
         ]
       },
       // --- Shell sourcing ---

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -177,6 +177,7 @@ export const DEFAULT_CONFIG: WardenConfig = {
         default: 'ask',
         argPatterns: [
           { match: { anyArgMatches: ['^--(version|help)$', '^-[vh]$'] }, decision: 'allow', description: 'Version/help flags' },
+          { match: { argsMatch: ['^plugin(s)?\\s+(list|help|validate|marketplace\\s+(list|help))\\b'] }, decision: 'allow', description: 'Read-only plugin commands' },
         ],
       },
 


### PR DESCRIPTION
## Summary
- Allow `claude plugin list`, `plugin help`, `plugin validate`, and `plugin marketplace list/help` without prompting
- Mutating subcommands (`install`, `uninstall`, `update`, `enable`, `disable`, `marketplace add/remove/update`) still require confirmation

## Test plan
- [x] Existing tests pass
- [ ] Verify `claude plugin marketplace list` no longer triggers warden prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)