### PR TITLE
fix: rm flag regex falsely matching filenames with hyphens

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -19796,8 +19796,8 @@ var DEFAULT_CONFIG = {
         command: "rm",
         default: "ask",
         argPatterns: [
-          { match: { argsMatch: ["-[^\\s]*r[^\\s]*f|-[^\\s]*f[^\\s]*r"] }, decision: "ask", reason: "Recursive force delete (rm -rf)" },
-          { match: { argsMatch: ["-[^\\s]*r"] }, decision: "ask", reason: "Recursive delete" },
+          { match: { anyArgMatches: ["^-[^\\s]*r[^\\s]*f$|^-[^\\s]*f[^\\s]*r$"] }, decision: "ask", reason: "Recursive force delete (rm -rf)" },
+          { match: { anyArgMatches: ["^-[^\\s]*r"] }, decision: "ask", reason: "Recursive delete" },
           { match: { argCount: { max: 3 }, not: false }, decision: "allow", description: "Deleting a small number of non-recursive files" }
         ]
       },

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -367,8 +367,8 @@ export const DEFAULT_CONFIG: WardenConfig = {
         command: 'rm',
         default: 'ask',
         argPatterns: [
-          { match: { argsMatch: ['-[^\\s]*r[^\\s]*f|-[^\\s]*f[^\\s]*r'] }, decision: 'ask', reason: 'Recursive force delete (rm -rf)' },
-          { match: { argsMatch: ['-[^\\s]*r'] }, decision: 'ask', reason: 'Recursive delete' },
+          { match: { anyArgMatches: ['^-[^\\s]*r[^\\s]*f$|^-[^\\s]*f[^\\s]*r$'] }, decision: 'ask', reason: 'Recursive force delete (rm -rf)' },
+          { match: { anyArgMatches: ['^-[^\\s]*r'] }, decision: 'ask', reason: 'Recursive delete' },
           { match: { argCount: { max: 3 }, not: false }, decision: 'allow', description: 'Deleting a small number of non-recursive files' },
         ],
       },


### PR DESCRIPTION
## Summary
- `rm /tmp/sample-worktree-config.yaml` was incorrectly flagged as "Recursive force delete (rm -rf)"
- Root cause: `argsMatch` uses `.test()` substring matching, so `-[^\s]*r[^\s]*f` matched the `-worktree-config.yaml` substring in the path
- Fix: switch to `anyArgMatches` with `^...$` anchors so flag patterns only match actual flag arguments, not filenames

## Test plan
- [x] Existing evaluator and integration tests pass
- [ ] Verify `rm /tmp/some-file-with-hyphens.txt` no longer triggers false positive

🤖 Generated with [Claude Code](https://claude.com/claude-code)