### PR TITLE
chore: bump version to 2.1.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "description": "Smart command safety filter for Claude Code — parses shell pipelines and evaluates per-command safety rules to auto-approve safe commands and block dangerous ones",
   "author": {
     "name": "banyudu"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-warden",
-  "version": "2.0.1",
+  "version": "2.1.1",
   "description": "Smart command safety filter for Claude Code — auto-approves safe commands, blocks dangerous ones",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary
- Bump version in package.json and plugin.json from 2.0.1 to 2.1.1
- Was missed in v2.1.0 and v2.1.1 releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)