### PR TITLE
chore: release v2.2.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Smart command safety filter for Claude Code — parses shell pipelines and evaluates per-command safety rules to auto-approve safe commands and block dangerous ones",
   "author": {
     "name": "banyudu"

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,87 @@
+---
+description: Release a new version with changelog and GitHub release. Accepts optional argument: patch, minor, or major.
+user_invocable: true
+---
+
+# Release Skill
+
+When invoked, perform a versioned release of claude-warden with changelog updates and a GitHub release.
+
+## Steps
+
+### 1. Sync with remote
+
+Before anything else, pull the latest changes from the remote main branch:
+
+```
+git pull --rebase
+```
+
+This ensures the changelog and version bump account for all merged changes, not just local commits.
+
+### 2. Determine version bump
+
+If the user provided an argument (`patch`, `minor`, or `major`), use that.
+
+If no argument is provided, auto-decide based on commits since the last tag:
+- If any commit has a `feat:` or `feat(` prefix → **minor**
+- Otherwise → **patch**
+- **NEVER auto-select `major`** — major version bumps must always be explicitly requested by the user
+
+### 3. Generate changelog entry
+
+Compare the current HEAD against the last git tag to find all commits since the last release:
+
+```
+git log $(git describe --tags --abbrev=0)..HEAD --oneline
+```
+
+Group commits by type based on conventional commit prefixes:
+- **Features** — `feat:` commits
+- **Bug Fixes** — `fix:` commits
+- **Other Changes** — everything else (`chore:`, `refactor:`, `docs:`, etc.)
+
+Skip empty sections. Format each entry as `- <commit message> (<short hash>)`.
+
+### 4. Update CHANGELOG.md
+
+Read the existing `CHANGELOG.md` (create it if missing). Insert the new version entry at the top, right after the `# Changelog` header. Use this format:
+
+```markdown
+## [<new-version>] - <YYYY-MM-DD>
+
+### Features
+- commit message (abc1234)
+
+### Bug Fixes
+- commit message (def5678)
+
+### Other Changes
+- commit message (ghi9012)
+```
+
+### 5. Build and test
+
+1. `pnpm version <bump> --no-git-tag-version` — bump version
+2. `pnpm run sync-plugin-version` — sync plugin.json version
+3. `pnpm run build` — build
+4. `pnpm run test` — run tests
+
+### 6. Create release PR
+
+Since `main` has branch protection, push via a release branch:
+
+1. `git checkout -b release/v<version>`
+2. Stage changes: `git add package.json .claude-plugin/plugin.json CHANGELOG.md dist/` plus any new files (e.g. `vitest.config.ts`). Use `git add -f` for gitignored paths like `.claude/`.
+3. Commit with message: `chore: release v<version>` — this exact format triggers the auto-release CI workflow.
+4. Push: `git push -u origin release/v<version>`
+5. Create PR: `gh pr create --title "chore: release v<version>" --body "<changelog>" --base main`
+
+**After the PR is merged**, CI automatically:
+- Creates the git tag `v<version>`
+- Creates the GitHub release with changelog notes
+- Publishes to npm via the existing publish workflow
+
+### 7. Report
+
+Tell the user the PR is created. Once merged, the release will be published automatically.

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,44 @@
+name: Auto Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: startsWith(github.event.head_commit.message, 'chore: release v')
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract version from commit message
+        id: version
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          VERSION=$(echo "$COMMIT_MSG" | grep -oP 'v\d+\.\d+\.\d+')
+          if [ -z "$VERSION" ]; then
+            echo "No version found in commit message"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Extract changelog for this version
+        id: changelog
+        env:
+          VERSION_TAG: ${{ steps.version.outputs.version }}
+        run: |
+          VERSION_NUM="${VERSION_TAG#v}"
+          CHANGELOG=$(awk "/^## \[${VERSION_NUM}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
+          echo "notes<<CHANGELOG_EOF" >> "$GITHUB_OUTPUT"
+          echo "$CHANGELOG" >> "$GITHUB_OUTPUT"
+          echo "CHANGELOG_EOF" >> "$GITHUB_OUTPUT"
+      - name: Create tag and release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_NOTES: ${{ steps.changelog.outputs.notes }}
+        run: |
+          git tag "$VERSION"
+          git push origin "$VERSION"
+          gh release create "$VERSION" --title "$VERSION" --notes "$RELEASE_NOTES"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.2.0] - 2026-03-15
+
+### Features
+- Support WARDEN_YOLO env var for non-interactive sessions (bd16d76)
+- Update publish command to exclude git checks (af2a56f)
+- Add vitest config to exclude worktree test files from test runs
+- Update `/release` skill to auto-decide version bump (patch/minor) based on commit types, never auto-select major
+
 ## [2.0.0] - 2026-03-09
 
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-warden",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Smart command safety filter for Claude Code — auto-approves safe commands, blocks dangerous ones",
   "type": "module",
   "main": "dist/index.cjs",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/.worktrees/**',
+    ],
+  },
+});


### PR DESCRIPTION
## Summary
- Support WARDEN_YOLO env var for non-interactive sessions (bd16d76)
- Update publish command to exclude git checks (af2a56f)
- Add vitest config to exclude worktree test files from test runs
- Update `/release` skill to auto-decide version bump and sync with remote before releasing
- Add auto-release CI workflow — creates tag + GitHub release when version bump PR is merged

## Release automation
The commit message `chore: release v2.2.0` triggers the new `auto-release.yml` workflow on merge, which:
1. Creates git tag `v2.2.0`
2. Creates GitHub release with changelog
3. Triggers `publish.yml` to publish to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)