### PR TITLE
fix(ci): add npm publish to auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     if: "startsWith(github.event.head_commit.message, 'chore: release v')"
     steps:
       - uses: actions/checkout@v4
@@ -42,3 +43,15 @@ jobs:
           git tag "$VERSION"
           git push origin "$VERSION"
           gh release create "$VERSION" --title "$VERSION" --notes "$RELEASE_NOTES"
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run test
+      - run: pnpm run build
+      - run: pnpm publish --access public --no-git-checks --provenance


### PR DESCRIPTION
## Summary
- Merged npm publish steps from `publish.yml` into `auto-release.yml`
- `GITHUB_TOKEN` events don't trigger other workflows, so the GitHub release created by `auto-release.yml` was never triggering `publish.yml`
- `publish.yml` is kept as fallback for manual `gh release create` releases

## Test plan
- [ ] Merge this PR, then do a release — verify npm publish runs as part of auto-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)