### PR TITLE
feat: add Fly.io SSH support with trustedFlyApps

### DIFF
--- a/config/warden.default.yaml
+++ b/config/warden.default.yaml
@@ -73,6 +73,16 @@ notifyOnDeny: true
 #     overrides:
 #       alwaysAllow: [sudo, apt]
 
+# Trusted Fly.io apps — fly ssh console to these apps are auto-allowed.
+# Remote commands (-C or after --) are recursively evaluated through warden rules.
+# trustedFlyApps:
+#   - my-fly-app
+#   - name: staging-*
+#     allowAll: true
+#   - name: prod-app
+#     overrides:
+#       alwaysAllow: [sudo, apt]
+
 # Override rules when evaluating commands inside trusted remote contexts
 # (docker exec, kubectl exec, ssh, sprite exec). These overrides are applied
 # as the highest-priority layer only for remote command evaluation.

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -18548,6 +18548,10 @@ function evaluateCommand(cmd, config, depth = 0) {
     const spriteResult = evaluateSpriteExec(cmd, config, depth);
     if (spriteResult) return spriteResult;
   }
+  if ((command === "fly" || command === "flyctl") && config.trustedFlyApps?.length) {
+    const flyResult = evaluateFlyCommand(cmd, config, depth);
+    if (flyResult) return flyResult;
+  }
   if (command === "xargs") {
     return evaluateXargsCommand(cmd, config, depth);
   }
@@ -19216,6 +19220,93 @@ function evaluateSpriteExec(cmd, config, depth = 0) {
     matchedRule: "trustedSprites"
   };
 }
+var FLY_SSH_FLAGS_WITH_VALUE = /* @__PURE__ */ new Set([
+  "-a",
+  "--app",
+  "-C",
+  "--command",
+  "-o",
+  "--org",
+  "-r",
+  "--region",
+  "-u",
+  "--user",
+  "--address"
+]);
+function parseFlySSHArgs(args2) {
+  let app = null;
+  const remoteArgs = [];
+  let isSSH = false;
+  let foundConsole = false;
+  let i = 0;
+  while (i < args2.length) {
+    const arg = args2[i];
+    if (arg.startsWith("--app=")) {
+      app = arg.slice(6);
+      i++;
+      continue;
+    }
+    if (FLY_SSH_FLAGS_WITH_VALUE.has(arg)) {
+      if (arg === "-a" || arg === "--app") {
+        app = args2[i + 1] || null;
+      }
+      if ((arg === "-C" || arg === "--command") && foundConsole) {
+        const cmdValue = args2[i + 1];
+        if (cmdValue) {
+          const parsed = parseCommand(cmdValue);
+          if (!parsed.parseError && parsed.commands.length > 0) {
+            const cmd = parsed.commands[0];
+            remoteArgs.push(cmd.command, ...cmd.args);
+          }
+        }
+        i += 2;
+        continue;
+      }
+      i += 2;
+      continue;
+    }
+    if (arg === "--") {
+      i++;
+      while (i < args2.length) {
+        remoteArgs.push(args2[i]);
+        i++;
+      }
+      break;
+    }
+    if (arg.startsWith("-")) {
+      i++;
+      continue;
+    }
+    if (!isSSH && arg === "ssh") {
+      isSSH = true;
+      i++;
+      continue;
+    }
+    if (isSSH && !foundConsole && (arg === "console" || arg === "sftp")) {
+      foundConsole = true;
+      i++;
+      continue;
+    }
+    i++;
+  }
+  return { app, remoteArgs, isSSH: isSSH && foundConsole };
+}
+function evaluateFlyCommand(cmd, config, depth = 0) {
+  const { command, args: args2 } = cmd;
+  const { app, remoteArgs, isSSH } = parseFlySSHArgs(args2);
+  if (!isSSH) return null;
+  if (!app) return null;
+  const matched = findMatchingTarget(app, config.trustedFlyApps || []);
+  if (!matched) return null;
+  const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);
+  return {
+    command,
+    args: args2,
+    decision: result.decision,
+    reason: `Trusted Fly app "${app}" (${result.reason})`,
+    matchedRule: "trustedFlyApps"
+  };
+}
 
 // src/rules.ts
 var import_fs = require("fs");
@@ -19373,6 +19464,7 @@ var DEFAULT_CONFIG = {
   trustedDockerContainers: [],
   trustedKubectlContexts: [],
   trustedSprites: [],
+  trustedFlyApps: [],
   layers: [{
     alwaysAllow: [
       // Read-only file operations
@@ -19885,6 +19977,17 @@ var DEFAULT_CONFIG = {
         { match: { anyArgMatches: ["^(list|search|show|status|get|template|version|env|history)$"] }, decision: "allow", description: "Read-only helm commands" },
         VERSION_HELP_FLAGS
       ] },
+      // --- Fly.io ---
+      ...["fly", "flyctl"].map((cmd) => ({
+        command: cmd,
+        default: "ask",
+        argPatterns: [
+          { match: { anyArgMatches: ["^(status|logs|info|version|platform|doctor|dig)$"] }, decision: "allow", description: "Read-only fly commands" },
+          { match: { argsMatch: ["^apps\\s+list"] }, decision: "allow", description: "List fly apps" },
+          { match: { anyArgMatches: ["^(deploy|destroy|scale|secrets)$"] }, decision: "ask", reason: "Destructive fly operation" },
+          VERSION_HELP_FLAGS
+        ]
+      })),
       // --- Screen/tmux ---
       ...["screen", "tmux"].map((cmd) => ({
         command: cmd,
@@ -20070,6 +20173,9 @@ function mergeNonLayerFields(config, raw) {
   }
   if (Array.isArray(raw.trustedSprites)) {
     config.trustedSprites = [...config.trustedSprites || [], ...parseTrustedList(raw.trustedSprites)];
+  }
+  if (Array.isArray(raw.trustedFlyApps)) {
+    config.trustedFlyApps = [...config.trustedFlyApps || [], ...parseTrustedList(raw.trustedFlyApps)];
   }
   if (typeof raw.defaultDecision === "string") {
     if (isValidDecision(raw.defaultDecision)) {

--- a/src/__tests__/evaluator.test.ts
+++ b/src/__tests__/evaluator.test.ts
@@ -1021,4 +1021,70 @@ describe('evaluator', () => {
       expect(result.decision).toBe('deny');
     });
   });
+
+  describe('fly / flyctl trusted apps', () => {
+    const apps = ['my-app', 'staging-*'];
+
+    it('allows fly ssh console with safe command on trusted app', () => {
+      expect(evalWith('fly ssh console -a my-app -C "ls -la"', { trustedFlyApps: toTargets(apps) }).decision).toBe('allow');
+    });
+
+    it('allows fly ssh console interactive (no command)', () => {
+      expect(evalWith('fly ssh console -a my-app', { trustedFlyApps: toTargets(apps) }).decision).toBe('allow');
+    });
+
+    it('allows --app=value syntax', () => {
+      expect(evalWith('fly ssh console --app=my-app -C "ls -la"', { trustedFlyApps: toTargets(apps) }).decision).toBe('allow');
+    });
+
+    it('denies fly ssh console with dangerous command on trusted app', () => {
+      expect(evalWith('fly ssh console -a my-app -C "sudo rm -rf /"', { trustedFlyApps: toTargets(apps) }).decision).toBe('deny');
+    });
+
+    it('asks for untrusted app', () => {
+      expect(evalWith('fly ssh console -a unknown-app -C "ls"', { trustedFlyApps: toTargets(apps) }).decision).toBe('ask');
+    });
+
+    it('supports glob matching', () => {
+      expect(evalWith('fly ssh console -a staging-web -C "ls"', { trustedFlyApps: toTargets(apps) }).decision).toBe('allow');
+    });
+
+    it('evaluates shell -c commands recursively', () => {
+      expect(evalWith('fly ssh console -a my-app -C "bash -c \\"ls | grep foo\\""', { trustedFlyApps: toTargets(apps) }).decision).toBe('allow');
+    });
+
+    it('flyctl alias works same as fly', () => {
+      expect(evalWith('flyctl ssh console -a my-app -C "ls"', { trustedFlyApps: toTargets(apps) }).decision).toBe('allow');
+    });
+
+    it('allowAll on trusted app allows everything', () => {
+      expect(evalWith('fly ssh console -a my-app -C "sudo rm -rf /"', {
+        trustedFlyApps: [{ name: 'my-app', allowAll: true }],
+      }).decision).toBe('allow');
+    });
+
+    it('per-app overrides work', () => {
+      expect(evalWith('fly ssh console -a my-app -C "sudo apt install vim"', {
+        trustedFlyApps: [{ name: 'my-app', overrides: { alwaysAllow: ['sudo', 'apt'], alwaysDeny: [], rules: [] } }],
+      }).decision).toBe('allow');
+    });
+
+    it('non-ssh fly commands fall through to regular rules', () => {
+      const result = evalWith('fly status', { trustedFlyApps: toTargets(apps) });
+      expect(result.decision).toBe('allow');
+    });
+
+    it('fly deploy still asks', () => {
+      const result = evalWith('fly deploy', { trustedFlyApps: toTargets(apps) });
+      expect(result.decision).toBe('ask');
+    });
+
+    it('allows -- syntax for remote command', () => {
+      expect(evalWith('fly ssh console -a my-app -- ls -la', { trustedFlyApps: toTargets(apps) }).decision).toBe('allow');
+    });
+
+    it('allows bare bash on trusted app (interactive shell)', () => {
+      expect(evalWith('fly ssh console -a my-app -C "bash"', { trustedFlyApps: toTargets(apps) }).decision).toBe('allow');
+    });
+  });
 });

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -96,6 +96,7 @@ export const DEFAULT_CONFIG: WardenConfig = {
   trustedDockerContainers: [],
   trustedKubectlContexts: [],
   trustedSprites: [],
+  trustedFlyApps: [],
 
   layers: [{
     alwaysAllow: [
@@ -467,6 +468,18 @@ export const DEFAULT_CONFIG: WardenConfig = {
         { match: { anyArgMatches: ['^(list|search|show|status|get|template|version|env|history)$'] }, decision: 'allow', description: 'Read-only helm commands' },
         VERSION_HELP_FLAGS,
       ]},
+
+      // --- Fly.io ---
+      ...['fly', 'flyctl'].map((cmd): CommandRule => ({
+        command: cmd,
+        default: 'ask',
+        argPatterns: [
+          { match: { anyArgMatches: ['^(status|logs|info|version|platform|doctor|dig)$'] }, decision: 'allow', description: 'Read-only fly commands' },
+          { match: { argsMatch: ['^apps\\s+list'] }, decision: 'allow', description: 'List fly apps' },
+          { match: { anyArgMatches: ['^(deploy|destroy|scale|secrets)$'] }, decision: 'ask', reason: 'Destructive fly operation' },
+          VERSION_HELP_FLAGS,
+        ],
+      })),
 
       // --- Screen/tmux ---
       ...['screen', 'tmux'].map((cmd): CommandRule => ({

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -121,6 +121,10 @@ function evaluateCommand(cmd: ParsedCommand, config: WardenConfig, depth: number
     const spriteResult = evaluateSpriteExec(cmd, config, depth);
     if (spriteResult) return spriteResult;
   }
+  if ((command === 'fly' || command === 'flyctl') && config.trustedFlyApps?.length) {
+    const flyResult = evaluateFlyCommand(cmd, config, depth);
+    if (flyResult) return flyResult;
+  }
   if (command === 'xargs') {
     return evaluateXargsCommand(cmd, config, depth);
   }
@@ -895,5 +899,113 @@ function evaluateSpriteExec(cmd: ParsedCommand, config: WardenConfig, depth: num
     decision: result.decision,
     reason: `Trusted sprite "${spriteName}" (${result.reason})`,
     matchedRule: 'trustedSprites',
+  };
+}
+
+// ─── Fly.io SSH whitelisting ───
+
+/** Fly SSH flags that consume the next argument. */
+const FLY_SSH_FLAGS_WITH_VALUE = new Set([
+  '-a', '--app', '-C', '--command', '-o', '--org', '-r', '--region',
+  '-u', '--user', '--address',
+]);
+
+interface FlySSHParseResult {
+  app: string | null;
+  remoteArgs: string[];
+  isSSH: boolean;
+}
+
+function parseFlySSHArgs(args: string[]): FlySSHParseResult {
+  let app: string | null = null;
+  const remoteArgs: string[] = [];
+  let isSSH = false;
+  let foundConsole = false;
+  let i = 0;
+
+  // Look for `ssh console` subcommand sequence
+  while (i < args.length) {
+    const arg = args[i];
+
+    // Handle --app=value syntax
+    if (arg.startsWith('--app=')) {
+      app = arg.slice(6);
+      i++;
+      continue;
+    }
+
+    if (FLY_SSH_FLAGS_WITH_VALUE.has(arg)) {
+      if (arg === '-a' || arg === '--app') {
+        app = args[i + 1] || null;
+      }
+      if ((arg === '-C' || arg === '--command') && foundConsole) {
+        // Everything after -C is the remote command
+        const cmdValue = args[i + 1];
+        if (cmdValue) {
+          // Parse the command string into args
+          const parsed = parseCommand(cmdValue);
+          if (!parsed.parseError && parsed.commands.length > 0) {
+            const cmd = parsed.commands[0];
+            remoteArgs.push(cmd.command, ...cmd.args);
+          }
+        }
+        i += 2;
+        continue;
+      }
+      i += 2;
+      continue;
+    }
+
+    if (arg === '--') {
+      // Everything after -- is the remote command
+      i++;
+      while (i < args.length) {
+        remoteArgs.push(args[i]);
+        i++;
+      }
+      break;
+    }
+
+    if (arg.startsWith('-')) {
+      i++;
+      continue;
+    }
+
+    // Positional args: look for ssh -> console
+    if (!isSSH && arg === 'ssh') {
+      isSSH = true;
+      i++;
+      continue;
+    }
+
+    if (isSSH && !foundConsole && (arg === 'console' || arg === 'sftp')) {
+      foundConsole = true;
+      i++;
+      continue;
+    }
+
+    i++;
+  }
+
+  return { app, remoteArgs, isSSH: isSSH && foundConsole };
+}
+
+function evaluateFlyCommand(cmd: ParsedCommand, config: WardenConfig, depth: number = 0): CommandEvalDetail | null {
+  const { command, args } = cmd;
+  const { app, remoteArgs, isSSH } = parseFlySSHArgs(args);
+
+  // Only handle ssh console — other fly commands fall through to regular rules
+  if (!isSSH) return null;
+  if (!app) return null;
+
+  const matched = findMatchingTarget(app, config.trustedFlyApps || []);
+  if (!matched) return null;
+
+  const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);
+  return {
+    command, args,
+    decision: result.decision,
+    reason: `Trusted Fly app "${app}" (${result.reason})`,
+    matchedRule: 'trustedFlyApps',
   };
 }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -179,6 +179,9 @@ function mergeNonLayerFields(config: WardenConfig, raw: Record<string, unknown>)
   if (Array.isArray(raw.trustedSprites)) {
     config.trustedSprites = [...(config.trustedSprites || []), ...parseTrustedList(raw.trustedSprites)];
   }
+  if (Array.isArray(raw.trustedFlyApps)) {
+    config.trustedFlyApps = [...(config.trustedFlyApps || []), ...parseTrustedList(raw.trustedFlyApps)];
+  }
   if (typeof raw.defaultDecision === 'string') {
     if (isValidDecision(raw.defaultDecision)) {
       config.defaultDecision = raw.defaultDecision;

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export interface WardenConfig {
   trustedDockerContainers?: TrustedTarget[];
   trustedKubectlContexts?: TrustedTarget[];
   trustedSprites?: TrustedTarget[];
+  trustedFlyApps?: TrustedTarget[];
   trustedContextOverrides?: ConfigLayer;
   defaultDecision: Decision;
   askOnSubshell: boolean;


### PR DESCRIPTION
## Summary
- Add `trustedFlyApps` config option for whitelisting `fly ssh console` / `flyctl ssh console` commands
- Follows the same trusted-context pattern as SSH hosts, Docker containers, kubectl contexts, and sprites
- Remote commands (`-C` or after `--`) are recursively evaluated through warden rules
- Supports glob patterns, `allowAll`, and per-app overrides
- Adds `fly`/`flyctl` command rules for read-only commands (status, logs, etc.)

Closes #59

## Test plan
- [x] 14 new tests covering trusted/untrusted apps, glob matching, `--app=` syntax, `--` syntax, allowAll, per-app overrides, `flyctl` alias, shell -c recursion, non-SSH fallthrough
- [x] All 429 tests pass
- [x] TypeScript typecheck passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)