### PR TITLE
feat: data-aware security policies with target-based rule overrides

### DIFF
--- a/config/warden.default.yaml
+++ b/config/warden.default.yaml
@@ -30,58 +30,100 @@ notifyOnDeny: true
 #   - nc
 #   - ncat
 
-# Trusted SSH hosts — ssh/scp/rsync to these hosts are auto-allowed.
-# Remote commands on trusted hosts are recursively evaluated through warden rules.
-# Supports glob patterns (* wildcards).
-# Entries can be strings (use global overrides) or objects with per-target settings.
-# trustedSSHHosts:
-#   - devserver                          # string → uses global overrides only
-#   - staging-*
-#   - "*.internal.company.com"
-#   - name: prod-bastion                 # object with per-target overrides
+# Remote execution contexts — SSH, Docker, kubectl, Sprite, Fly.io
+# Commands on trusted remotes are recursively evaluated through warden rules.
+# Supports glob patterns (* wildcards) for names.
+# trustedRemotes:
+#   - context: ssh
+#     name: devserver
+#   - context: ssh
+#     name: staging-*
+#   - context: ssh
+#     name: "*.internal.company.com"
+#   - context: ssh
+#     name: prod-bastion
 #     overrides:
 #       alwaysAllow: [systemctl]
-
-# Trusted Docker containers — docker exec to these containers are auto-allowed.
-# Remote commands are recursively evaluated through warden rules.
-# trustedDockerContainers:
-#   - my-app                             # string → uses global overrides only
-#   - name: dev-container                # object with allowAll (skip all checks)
-#     allowAll: true
-#   - name: staging-*                    # object with per-target overrides
+#   - context: docker
+#     name: my-app
+#   - context: docker
+#     name: dev-container
+#     allowAll: true                 # skip all checks (disposable env)
+#   - context: docker
+#     name: staging-*
 #     overrides:
 #       alwaysAllow: [sudo, apt]
-
-# Trusted kubectl contexts — kubectl exec in these contexts are auto-allowed.
-# Remote commands (after --) are recursively evaluated through warden rules.
-# trustedKubectlContexts:
-#   - minikube
-#   - name: dev-cluster-*
+#   - context: kubectl
+#     name: minikube
+#   - context: kubectl
+#     name: dev-cluster-*
 #     overrides:
 #       alwaysAllow: [sudo]
-#   - name: prod-cluster
+#   - context: kubectl
+#     name: prod-cluster
 #     overrides:
 #       alwaysDeny: [rm]
-
-# Trusted Sprites — sprite exec/console to these sprites are auto-allowed.
-# Remote commands are recursively evaluated through warden rules.
-# trustedSprites:
-#   - my-sprite                          # string → uses global overrides only
-#   - name: yudu-claw                    # allowAll: skip all checks (disposable env)
+#   - context: sprite
+#     name: my-sprite
+#   - context: sprite
+#     name: yudu-claw
 #     allowAll: true
-#   - name: dev-*                        # per-target overrides
+#   - context: sprite
+#     name: dev-*
+#     overrides:
+#       alwaysAllow: [sudo, apt]
+#   - context: fly
+#     name: my-fly-app
+#   - context: fly
+#     name: staging-*
+#     allowAll: true
+#   - context: fly
+#     name: prod-app
 #     overrides:
 #       alwaysAllow: [sudo, apt]
 
-# Trusted Fly.io apps — fly ssh console to these apps are auto-allowed.
-# Remote commands (-C or after --) are recursively evaluated through warden rules.
-# trustedFlyApps:
-#   - my-fly-app
-#   - name: staging-*
-#     allowAll: true
-#   - name: prod-app
-#     overrides:
-#       alwaysAllow: [sudo, apt]
+# Target-based policies — override decisions based on paths, databases, or endpoints.
+# targetPolicies:
+#   - type: path
+#     path: /tmp
+#     allowAll: true                 # any command targeting /tmp is auto-allowed
+#   - type: path
+#     path: "{{cwd}}"               # expands to the project's working directory
+#     decision: allow
+#     commands: [rm, cp, mv]        # only override these commands
+#   - type: path
+#     path: /etc
+#     decision: deny                # block modifications to /etc
+#     reason: "System config directory"
+#   - type: path
+#     path: /opt/build
+#     recursive: false              # exact match only (not children)
+#     decision: allow
+#   - type: database
+#     host: localhost
+#     decision: allow
+#   - type: database
+#     host: "dev-*.internal"
+#     database: "test_*"
+#     decision: allow
+#   - type: database
+#     host: "prod.example.com"
+#     decision: deny
+#     reason: "Production database"
+#   - type: endpoint
+#     pattern: "http://localhost:*"
+#     decision: allow
+#   - type: endpoint
+#     pattern: "https://api.dev.example.com/*"
+#     decision: allow
+#   - type: endpoint
+#     pattern: "https://api.prod.example.com/*"
+#     decision: deny
+#     reason: "Production API"
+
+# Legacy keys (trustedSSHHosts, trustedDockerContainers, trustedKubectlContexts,
+# trustedSprites, trustedFlyApps, trustedPaths, trustedDatabases, trustedEndpoints)
+# are still supported and automatically converted to the unified form above.
 
 # Override rules when evaluating commands inside trusted remote contexts
 # (docker exec, kubectl exec, ssh, sprite exec). These overrides are applied

--- a/dist/codex-export.cjs
+++ b/dist/codex-export.cjs
@@ -18137,7 +18137,7 @@ var require_dist2 = __commonJS({
 
 // src/codex-export.ts
 var import_fs2 = require("fs");
-var import_path3 = require("path");
+var import_path4 = require("path");
 
 // src/evaluator.ts
 var import_os = require("os");
@@ -18461,6 +18461,282 @@ function regexFallbackParse(input) {
   return { command, originalCommand, args: args2, envPrefixes, raw: trimmed };
 }
 
+// src/targets.ts
+var import_path2 = require("path");
+
+// src/glob.ts
+function globToRegex(pattern) {
+  let regex = "";
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === "*") {
+      regex += ".*";
+    } else if (ch === "?") {
+      regex += ".";
+    } else if (ch === "[") {
+      i++;
+      if (i < pattern.length && pattern[i] === "!") {
+        regex += "[^";
+        i++;
+      } else {
+        regex += "[";
+      }
+      while (i < pattern.length && pattern[i] !== "]") {
+        regex += pattern[i];
+        i++;
+      }
+      if (i < pattern.length) regex += "]";
+    } else if (ch === "{") {
+      const end = pattern.indexOf("}", i);
+      if (end !== -1) {
+        const alternatives = pattern.slice(i + 1, end).split(",").map((s) => s.replace(/[.+^$|\\()]/g, "\\$&"));
+        regex += `(${alternatives.join("|")})`;
+        i = end;
+      } else {
+        regex += "\\{";
+      }
+    } else if (".+^$|\\()".includes(ch)) {
+      regex += "\\" + ch;
+    } else {
+      regex += ch;
+    }
+    i++;
+  }
+  return new RegExp(`^${regex}$`);
+}
+
+// src/targets.ts
+var PATH_COMMANDS = /* @__PURE__ */ new Set([
+  "rm",
+  "chmod",
+  "chown",
+  "cp",
+  "mv",
+  "tee",
+  "mkdir",
+  "rmdir",
+  "touch",
+  "ln"
+]);
+function evaluatePathTarget(cmd, cwd, targets) {
+  if (targets.length === 0) return null;
+  const positionalArgs = cmd.args.filter((a) => !a.startsWith("-"));
+  if (positionalArgs.length === 0) return null;
+  let bestMatch = null;
+  for (const target of targets) {
+    if (target.allowAll) {
+    } else {
+      if (target.commands && target.commands.length > 0 && !target.commands.includes(cmd.command)) {
+        continue;
+      }
+      if (!target.commands && !PATH_COMMANDS.has(cmd.command)) {
+        continue;
+      }
+    }
+    const targetPath = (0, import_path2.normalize)(target.path.replace(/\{\{cwd\}\}/g, cwd));
+    const recursive = target.recursive !== false;
+    for (const arg of positionalArgs) {
+      const resolvedArg = (0, import_path2.normalize)((0, import_path2.resolve)(cwd, arg));
+      const matches = recursive ? resolvedArg === targetPath || resolvedArg.startsWith(targetPath + "/") : resolvedArg === targetPath;
+      if (matches) {
+        const decision = target.allowAll ? "allow" : target.decision;
+        const detail = {
+          command: cmd.command,
+          args: cmd.args,
+          decision,
+          reason: target.reason || `Path "${resolvedArg}" matches trusted path "${target.path}" (${decision})`,
+          matchedRule: "trustedPaths"
+        };
+        if (decision === "deny") return detail;
+        if (!bestMatch || bestMatch.decision !== "deny") {
+          bestMatch = detail;
+        }
+      }
+    }
+  }
+  return bestMatch;
+}
+var DB_HOST_FLAGS = {
+  psql: ["-h", "--host"],
+  mysql: ["-h", "--host"],
+  mariadb: ["-h", "--host"],
+  "redis-cli": ["-h"],
+  mongosh: ["--host"]
+};
+var DB_DATABASE_FLAGS = {
+  psql: ["-d", "--dbname"],
+  mysql: ["-D", "--database"],
+  mariadb: ["-D", "--database"]
+};
+var DB_PORT_FLAGS = {
+  psql: ["-p", "--port"],
+  mysql: ["-P", "--port"],
+  mariadb: ["-P", "--port"],
+  "redis-cli": ["-p"],
+  mongosh: ["--port"]
+};
+function extractFlagValue(args2, flags) {
+  for (let i = 0; i < args2.length; i++) {
+    const arg = args2[i];
+    for (const f of flags) {
+      if (arg.startsWith(f + "=")) {
+        return arg.slice(f.length + 1);
+      }
+    }
+    if (flags.includes(arg) && i + 1 < args2.length) {
+      return args2[i + 1];
+    }
+  }
+  return void 0;
+}
+function parseDBConnection(cmd) {
+  const command = cmd.command;
+  const info = {};
+  for (const arg of cmd.args) {
+    if (arg.startsWith("postgresql://") || arg.startsWith("postgres://")) {
+      try {
+        const url = new URL(arg);
+        info.host = url.hostname;
+        if (url.port) info.port = parseInt(url.port, 10);
+        if (url.pathname.length > 1) info.database = url.pathname.slice(1);
+        return info;
+      } catch {
+      }
+    }
+    if (arg.startsWith("mongodb://") || arg.startsWith("mongodb+srv://")) {
+      try {
+        const url = new URL(arg);
+        info.host = url.hostname;
+        if (url.port) info.port = parseInt(url.port, 10);
+        if (url.pathname.length > 1) info.database = url.pathname.slice(1);
+        return info;
+      } catch {
+      }
+    }
+  }
+  const hostFlags = DB_HOST_FLAGS[command];
+  if (hostFlags) {
+    const h = extractFlagValue(cmd.args, hostFlags);
+    if (h) info.host = h;
+  }
+  const dbFlags = DB_DATABASE_FLAGS[command];
+  if (dbFlags) {
+    const d = extractFlagValue(cmd.args, dbFlags);
+    if (d) info.database = d;
+  }
+  const portFlags = DB_PORT_FLAGS[command];
+  if (portFlags) {
+    const p = extractFlagValue(cmd.args, portFlags);
+    if (p) info.port = parseInt(p, 10);
+  }
+  return info;
+}
+var DB_COMMANDS = new Set(Object.keys(DB_HOST_FLAGS));
+function evaluateDatabaseTarget(cmd, targets) {
+  if (targets.length === 0) return null;
+  const hasAllowAll = targets.some((t) => t.allowAll);
+  if (!hasAllowAll && !DB_COMMANDS.has(cmd.command)) return null;
+  const applicableTargets = targets.filter((t) => t.allowAll || DB_COMMANDS.has(cmd.command));
+  if (applicableTargets.length === 0) return null;
+  const conn = parseDBConnection(cmd);
+  if (!conn.host) return null;
+  let bestMatch = null;
+  for (const target of applicableTargets) {
+    if (!target.allowAll && target.commands && target.commands.length > 0 && !target.commands.includes(cmd.command)) {
+      continue;
+    }
+    const hostMatch = globToRegex(target.host).test(conn.host);
+    if (!hostMatch) continue;
+    if (target.port !== void 0 && conn.port !== void 0 && target.port !== conn.port) {
+      continue;
+    }
+    if (target.database) {
+      if (!conn.database || !globToRegex(target.database).test(conn.database)) continue;
+    }
+    const decision = target.allowAll ? "allow" : target.decision;
+    const detail = {
+      command: cmd.command,
+      args: cmd.args,
+      decision,
+      reason: target.reason || `Database "${conn.host}${conn.database ? "/" + conn.database : ""}" matches trusted database (${decision})`,
+      matchedRule: "trustedDatabases"
+    };
+    if (decision === "deny") return detail;
+    if (!bestMatch) bestMatch = detail;
+  }
+  return bestMatch;
+}
+var ENDPOINT_COMMANDS = /* @__PURE__ */ new Set(["curl", "wget", "http", "httpie"]);
+function extractURLs(cmd) {
+  const urls = [];
+  const args2 = cmd.args;
+  for (let i = 0; i < args2.length; i++) {
+    const arg = args2[i];
+    if (arg === "--url" && i + 1 < args2.length) {
+      urls.push(args2[i + 1]);
+      i++;
+      continue;
+    }
+    if (arg.startsWith("http://") || arg.startsWith("https://")) {
+      urls.push(arg);
+    }
+  }
+  return urls;
+}
+function evaluateEndpointTarget(cmd, targets) {
+  if (targets.length === 0) return null;
+  const hasAllowAll = targets.some((t) => t.allowAll);
+  if (!hasAllowAll && !ENDPOINT_COMMANDS.has(cmd.command)) return null;
+  const urls = extractURLs(cmd);
+  if (urls.length === 0) return null;
+  let bestMatch = null;
+  for (const target of targets) {
+    if (!target.allowAll && target.commands && target.commands.length > 0 && !target.commands.includes(cmd.command)) {
+      continue;
+    }
+    for (const url of urls) {
+      if (globToRegex(target.pattern).test(url)) {
+        const decision = target.allowAll ? "allow" : target.decision;
+        const detail = {
+          command: cmd.command,
+          args: cmd.args,
+          decision,
+          reason: target.reason || `URL "${url}" matches trusted endpoint "${target.pattern}" (${decision})`,
+          matchedRule: "trustedEndpoints"
+        };
+        if (decision === "deny") return detail;
+        if (!bestMatch) bestMatch = detail;
+      }
+    }
+  }
+  return bestMatch;
+}
+function evaluateTargetPolicies(cmd, cwd, config) {
+  const policies = config.targetPolicies;
+  if (!policies?.length) return null;
+  const results = [];
+  const pathPolicies = policies.filter((p) => p.type === "path");
+  if (pathPolicies.length) {
+    const r = evaluatePathTarget(cmd, cwd, pathPolicies);
+    if (r) results.push(r);
+  }
+  const dbPolicies = policies.filter((p) => p.type === "database");
+  if (dbPolicies.length) {
+    const r = evaluateDatabaseTarget(cmd, dbPolicies);
+    if (r) results.push(r);
+  }
+  const endpointPolicies = policies.filter((p) => p.type === "endpoint");
+  if (endpointPolicies.length) {
+    const r = evaluateEndpointTarget(cmd, endpointPolicies);
+    if (r) results.push(r);
+  }
+  if (results.length === 0) return null;
+  const deny = results.find((r) => r.decision === "deny");
+  if (deny) return deny;
+  return results[0];
+}
+
 // src/evaluator.ts
 function safeRegexTest(pattern, input) {
   try {
@@ -18481,7 +18757,9 @@ function commandMatchesName(cmd, name) {
   return cmd.command === name;
 }
 var MAX_RECURSION_DEPTH = 10;
-function evaluate(parsed, config, depth = 0) {
+function evaluate(parsed, config, cwdOrDepth, maybeDepth) {
+  const cwd = typeof cwdOrDepth === "string" ? cwdOrDepth : void 0;
+  const depth = typeof cwdOrDepth === "number" ? cwdOrDepth : maybeDepth ?? 0;
   if (depth > MAX_RECURSION_DEPTH) {
     return { decision: "ask", reason: "Maximum recursion depth exceeded", details: [] };
   }
@@ -18494,7 +18772,7 @@ function evaluate(parsed, config, depth = 0) {
   if (parsed.hasSubshell && parsed.subshellCommands.length > 0) {
     for (const subCmd of parsed.subshellCommands) {
       const subParsed = parseCommand(subCmd);
-      const subResult = evaluate(subParsed, config, depth + 1);
+      const subResult = evaluate(subParsed, config, cwd, depth + 1);
       if (subResult.decision === "deny") {
         return { decision: "deny", reason: `Subshell command: ${subResult.reason}`, details: subResult.details };
       }
@@ -18507,7 +18785,7 @@ function evaluate(parsed, config, depth = 0) {
   }
   const details = [];
   for (const cmd of parsed.commands) {
-    details.push(evaluateCommand(cmd, config, depth));
+    details.push(evaluateCommand(cmd, config, cwd, depth));
   }
   const decisions = details.map((d) => d.decision);
   if (decisions.includes("deny")) {
@@ -18528,7 +18806,7 @@ function evaluate(parsed, config, depth = 0) {
   }
   return { decision: "allow", reason: "All commands are safe", details };
 }
-function evaluateCommand(cmd, config, depth = 0) {
+function evaluateCommand(cmd, config, cwd, depth = 0) {
   const { command, args: args2 } = cmd;
   for (const layer of config.layers) {
     if (layer.alwaysDeny.some((name) => commandMatchesName(cmd, name))) {
@@ -18538,27 +18816,51 @@ function evaluateCommand(cmd, config, depth = 0) {
       return { command, args: args2, decision: "allow", reason: `"${command}" is safe`, matchedRule: "alwaysAllow" };
     }
   }
-  if ((command === "ssh" || command === "scp" || command === "rsync") && config.trustedSSHHosts?.length) {
-    const sshResult = evaluateSSHCommand(cmd, config, depth);
-    if (sshResult) return sshResult;
+  if (cwd) {
+    const targetResult = evaluateTargetPolicies(cmd, cwd, config);
+    if (targetResult) return targetResult;
   }
-  if (command === "docker" && config.trustedDockerContainers?.length) {
-    const dockerResult = evaluateDockerExec(cmd, config, depth);
-    if (dockerResult) return dockerResult;
+  const remotes = config.trustedRemotes || [];
+  if (command === "ssh" || command === "scp" || command === "rsync") {
+    const sshTargets = remotes.filter((r) => r.context === "ssh");
+    if (sshTargets.length) {
+      const sshResult = evaluateSSHCommand(cmd, config, sshTargets, depth);
+      if (sshResult) return sshResult;
+    }
   }
-  if (command === "kubectl" && config.trustedKubectlContexts?.length) {
-    const kubectlResult = evaluateKubectlExec(cmd, config, depth);
-    if (kubectlResult) return kubectlResult;
+  if (command === "docker") {
+    const dockerTargets = remotes.filter((r) => r.context === "docker");
+    if (dockerTargets.length) {
+      const dockerResult = evaluateDockerExec(cmd, config, dockerTargets, depth);
+      if (dockerResult) return dockerResult;
+    }
   }
-  if (command === "sprite" && config.trustedSprites?.length) {
-    const spriteResult = evaluateSpriteExec(cmd, config, depth);
-    if (spriteResult) return spriteResult;
+  if (command === "kubectl") {
+    const kubectlTargets = remotes.filter((r) => r.context === "kubectl");
+    if (kubectlTargets.length) {
+      const kubectlResult = evaluateKubectlExec(cmd, config, kubectlTargets, depth);
+      if (kubectlResult) return kubectlResult;
+    }
+  }
+  if (command === "sprite") {
+    const spriteTargets = remotes.filter((r) => r.context === "sprite");
+    if (spriteTargets.length) {
+      const spriteResult = evaluateSpriteExec(cmd, config, spriteTargets, depth);
+      if (spriteResult) return spriteResult;
+    }
+  }
+  if (command === "fly" || command === "flyctl") {
+    const flyTargets = remotes.filter((r) => r.context === "fly");
+    if (flyTargets.length) {
+      const flyResult = evaluateFlyCommand(cmd, config, flyTargets, depth);
+      if (flyResult) return flyResult;
+    }
   }
   if (command === "xargs") {
-    return evaluateXargsCommand(cmd, config, depth);
+    return evaluateXargsCommand(cmd, config, cwd, depth);
   }
   if (command === "find") {
-    return evaluateFindCommand(cmd, config, depth);
+    return evaluateFindCommand(cmd, config, cwd, depth);
   }
   const mergedRule = collectMergedRule(cmd, config);
   if (mergedRule) {
@@ -18720,7 +19022,7 @@ function parseXargsSubcommand(args2) {
     }
   };
 }
-function evaluateXargsCommand(cmd, config, depth = 0) {
+function evaluateXargsCommand(cmd, config, cwd, depth = 0) {
   const { command, args: args2 } = cmd;
   const { subcommand, unresolved } = parseXargsSubcommand(args2);
   if (unresolved || !subcommand) {
@@ -18744,7 +19046,7 @@ function evaluateXargsCommand(cmd, config, depth = 0) {
   } else {
     parsed = { commands: [subcommand], hasSubshell: false, subshellCommands: [], parseError: false };
   }
-  const result = evaluate(parsed, config, depth + 1);
+  const result = evaluate(parsed, config, cwd, depth + 1);
   return {
     command,
     args: args2,
@@ -18782,7 +19084,7 @@ function parseFindExecCommands(args2) {
   }
   return commands;
 }
-function evaluateFindCommand(cmd, config, depth = 0) {
+function evaluateFindCommand(cmd, config, cwd, depth = 0) {
   const { command, args: args2 } = cmd;
   if (args2.some((a) => a === "-delete")) {
     return { command, args: args2, decision: "ask", reason: "find -delete can remove files", matchedRule: "find:delete" };
@@ -18801,7 +19103,7 @@ function evaluateFindCommand(cmd, config, depth = 0) {
       subshellCommands: [],
       parseError: false
     };
-    const result = evaluate(parsed, config, depth + 1);
+    const result = evaluate(parsed, config, cwd, depth + 1);
     if (result.decision === "deny") {
       return { command, args: args2, decision: "deny", reason: `find -exec: ${result.reason}`, matchedRule: "find:exec" };
     }
@@ -18833,48 +19135,6 @@ var SSH_FLAGS_WITH_VALUE = /* @__PURE__ */ new Set([
   "-W",
   "-w"
 ]);
-function globToRegex(pattern) {
-  let regex = "";
-  let i = 0;
-  while (i < pattern.length) {
-    const ch = pattern[i];
-    if (ch === "*") {
-      regex += ".*";
-    } else if (ch === "?") {
-      regex += ".";
-    } else if (ch === "[") {
-      i++;
-      if (i < pattern.length && pattern[i] === "!") {
-        regex += "[^";
-        i++;
-      } else {
-        regex += "[";
-      }
-      while (i < pattern.length && pattern[i] !== "]") {
-        regex += pattern[i];
-        i++;
-      }
-      if (i < pattern.length) {
-        regex += "]";
-      }
-    } else if (ch === "{") {
-      const end = pattern.indexOf("}", i);
-      if (end !== -1) {
-        const alternatives = pattern.slice(i + 1, end).split(",").map((s) => s.replace(/[.+^$|\\()]/g, "\\$&"));
-        regex += `(${alternatives.join("|")})`;
-        i = end;
-      } else {
-        regex += "\\{";
-      }
-    } else if (".+^$|\\()".includes(ch)) {
-      regex += "\\" + ch;
-    } else {
-      regex += ch;
-    }
-    i++;
-  }
-  return new RegExp(`^${regex}$`);
-}
 function findMatchingTarget(value, targets) {
   return targets.find((t) => globToRegex(t.name).test(value)) || null;
 }
@@ -18915,13 +19175,12 @@ function extractHostFromRemotePath(args2) {
   }
   return null;
 }
-function evaluateSSHCommand(cmd, config, depth = 0) {
+function evaluateSSHCommand(cmd, config, targets, depth = 0) {
   const { command, args: args2 } = cmd;
-  const trustedHosts = config.trustedSSHHosts || [];
   if (command === "scp" || command === "rsync") {
     const host2 = extractHostFromRemotePath(args2);
     if (!host2) return null;
-    const target2 = findMatchingTarget(host2, trustedHosts);
+    const target2 = findMatchingTarget(host2, targets);
     if (!target2) return null;
     if (target2.allowAll || !target2.overrides) {
       return {
@@ -18951,7 +19210,7 @@ function evaluateSSHCommand(cmd, config, depth = 0) {
   }
   const { host, remoteCommand } = parseSSHArgs(args2);
   if (!host) return null;
-  const target = findMatchingTarget(host, trustedHosts);
+  const target = findMatchingTarget(host, targets);
   if (!target) return null;
   if (!remoteCommand) {
     return {
@@ -19060,12 +19319,12 @@ function parseDockerExecArgs(args2) {
   }
   return { target, remoteArgs };
 }
-function evaluateDockerExec(cmd, config, depth = 0) {
+function evaluateDockerExec(cmd, config, targets, depth = 0) {
   const { command, args: args2 } = cmd;
   if (args2[0] !== "exec") return null;
   const { target: containerName, remoteArgs } = parseDockerExecArgs(args2.slice(1));
   if (!containerName) return null;
-  const matched = findMatchingTarget(containerName, config.trustedDockerContainers || []);
+  const matched = findMatchingTarget(containerName, targets);
   if (!matched) return null;
   const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);
   return {
@@ -19140,12 +19399,12 @@ function parseKubectlExecArgs(args2) {
   }
   return { context, pod, remoteArgs };
 }
-function evaluateKubectlExec(cmd, config, depth = 0) {
+function evaluateKubectlExec(cmd, config, targets, depth = 0) {
   const { command, args: args2 } = cmd;
   if (args2[0] !== "exec") return null;
   const { context, pod, remoteArgs } = parseKubectlExecArgs(args2.slice(1));
   if (!context) return null;
-  const matched = findMatchingTarget(context, config.trustedKubectlContexts || []);
+  const matched = findMatchingTarget(context, targets);
   if (!matched) return null;
   const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);
   return {
@@ -19207,11 +19466,11 @@ function parseSpriteExecArgs(args2) {
   }
   return { spriteName, remoteArgs };
 }
-function evaluateSpriteExec(cmd, config, depth = 0) {
+function evaluateSpriteExec(cmd, config, targets, depth = 0) {
   const { command, args: args2 } = cmd;
   const { spriteName, remoteArgs } = parseSpriteExecArgs(args2);
   if (!spriteName) return null;
-  const matched = findMatchingTarget(spriteName, config.trustedSprites || []);
+  const matched = findMatchingTarget(spriteName, targets);
   if (!matched) return null;
   const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);
   return {
@@ -19220,6 +19479,93 @@ function evaluateSpriteExec(cmd, config, depth = 0) {
     decision: result.decision,
     reason: `Trusted sprite "${spriteName}" (${result.reason})`,
     matchedRule: "trustedSprites"
+  };
+}
+var FLY_SSH_FLAGS_WITH_VALUE = /* @__PURE__ */ new Set([
+  "-a",
+  "--app",
+  "-C",
+  "--command",
+  "-o",
+  "--org",
+  "-r",
+  "--region",
+  "-u",
+  "--user",
+  "--address"
+]);
+function parseFlySSHArgs(args2) {
+  let app = null;
+  const remoteArgs = [];
+  let isSSH = false;
+  let foundConsole = false;
+  let i = 0;
+  while (i < args2.length) {
+    const arg = args2[i];
+    if (arg.startsWith("--app=")) {
+      app = arg.slice(6);
+      i++;
+      continue;
+    }
+    if (FLY_SSH_FLAGS_WITH_VALUE.has(arg)) {
+      if (arg === "-a" || arg === "--app") {
+        app = args2[i + 1] || null;
+      }
+      if ((arg === "-C" || arg === "--command") && foundConsole) {
+        const cmdValue = args2[i + 1];
+        if (cmdValue) {
+          const parsed = parseCommand(cmdValue);
+          if (!parsed.parseError && parsed.commands.length > 0) {
+            const cmd = parsed.commands[0];
+            remoteArgs.push(cmd.command, ...cmd.args);
+          }
+        }
+        i += 2;
+        continue;
+      }
+      i += 2;
+      continue;
+    }
+    if (arg === "--") {
+      i++;
+      while (i < args2.length) {
+        remoteArgs.push(args2[i]);
+        i++;
+      }
+      break;
+    }
+    if (arg.startsWith("-")) {
+      i++;
+      continue;
+    }
+    if (!isSSH && arg === "ssh") {
+      isSSH = true;
+      i++;
+      continue;
+    }
+    if (isSSH && !foundConsole && (arg === "console" || arg === "sftp")) {
+      foundConsole = true;
+      i++;
+      continue;
+    }
+    i++;
+  }
+  return { app, remoteArgs, isSSH: isSSH && foundConsole };
+}
+function evaluateFlyCommand(cmd, config, targets, depth = 0) {
+  const { command, args: args2 } = cmd;
+  const { app, remoteArgs, isSSH } = parseFlySSHArgs(args2);
+  if (!isSSH) return null;
+  if (!app) return null;
+  const matched = findMatchingTarget(app, targets);
+  if (!matched) return null;
+  const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);
+  return {
+    command,
+    args: args2,
+    decision: result.decision,
+    reason: `Trusted Fly app "${app}" (${result.reason})`,
+    matchedRule: "trustedFlyApps"
   };
 }
 
@@ -19272,7 +19618,7 @@ function generateCodexRules(config) {
 var import_fs = require("fs");
 var import_yaml = __toESM(require_dist2(), 1);
 var import_os2 = require("os");
-var import_path2 = require("path");
+var import_path3 = require("path");
 
 // src/defaults.ts
 var SAFE_DEV_TOOLS = [
@@ -19420,10 +19766,8 @@ var DEFAULT_CONFIG = {
   askOnSubshell: true,
   notifyOnAsk: true,
   notifyOnDeny: true,
-  trustedSSHHosts: [],
-  trustedDockerContainers: [],
-  trustedKubectlContexts: [],
-  trustedSprites: [],
+  trustedRemotes: [],
+  targetPolicies: [],
   layers: [{
     alwaysAllow: [
       // Read-only file operations
@@ -19946,6 +20290,17 @@ var DEFAULT_CONFIG = {
         { match: { anyArgMatches: ["^(list|search|show|status|get|template|version|env|history)$"] }, decision: "allow", description: "Read-only helm commands" },
         VERSION_HELP_FLAGS
       ] },
+      // --- Fly.io ---
+      ...["fly", "flyctl"].map((cmd) => ({
+        command: cmd,
+        default: "ask",
+        argPatterns: [
+          { match: { anyArgMatches: ["^(status|logs|info|version|platform|doctor|dig)$"] }, decision: "allow", description: "Read-only fly commands" },
+          { match: { argsMatch: ["^apps\\s+list"] }, decision: "allow", description: "List fly apps" },
+          { match: { anyArgMatches: ["^(deploy|destroy|scale|secrets)$"] }, decision: "ask", reason: "Destructive fly operation" },
+          VERSION_HELP_FLAGS
+        ]
+      })),
       // --- Screen/tmux ---
       ...["screen", "tmux"].map((cmd) => ({
         command: cmd,
@@ -19993,8 +20348,8 @@ function isValidDecision(value) {
   return VALID_DECISIONS.has(value);
 }
 var USER_CONFIG_PATHS = [
-  (0, import_path2.join)((0, import_os2.homedir)(), ".claude", "warden.yaml"),
-  (0, import_path2.join)((0, import_os2.homedir)(), ".claude", "warden.json")
+  (0, import_path3.join)((0, import_os2.homedir)(), ".claude", "warden.yaml"),
+  (0, import_path3.join)((0, import_os2.homedir)(), ".claude", "warden.json")
 ];
 var PROJECT_CONFIG_NAMES = [
   ".claude/warden.yaml",
@@ -20017,7 +20372,7 @@ function loadConfig(cwd) {
   let workspaceRaw = null;
   if (cwd) {
     for (const name of PROJECT_CONFIG_NAMES) {
-      const result = tryLoadFile((0, import_path2.join)(cwd, name));
+      const result = tryLoadFile((0, import_path3.join)(cwd, name));
       if (result) {
         workspaceLayer = extractLayer(result);
         workspaceRaw = result;
@@ -20119,18 +20474,153 @@ function parseTrustedList(raw) {
     return null;
   }).filter((t) => t !== null);
 }
+var VALID_REMOTE_CONTEXTS = /* @__PURE__ */ new Set(["ssh", "docker", "kubectl", "sprite", "fly"]);
+function parseTrustedRemotes(raw) {
+  const results = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const obj = entry;
+    const context = String(obj.context || "");
+    if (!VALID_REMOTE_CONTEXTS.has(context)) {
+      process.stderr.write(`[warden] Warning: unknown remote context "${context}", skipping
+`);
+      continue;
+    }
+    const name = String(obj.name || "");
+    if (!name) continue;
+    const remote = { name, context };
+    if (obj.allowAll === true) remote.allowAll = true;
+    if (obj.overrides && typeof obj.overrides === "object") {
+      remote.overrides = extractLayer(obj.overrides);
+    }
+    results.push(remote);
+  }
+  return results;
+}
+function parseTargetPolicies(raw) {
+  const results = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const obj = entry;
+    const type = String(obj.type || "");
+    const rawDecision = String(obj.decision || "allow");
+    const decision = isValidDecision(rawDecision) ? rawDecision : "allow";
+    const base = {
+      commands: Array.isArray(obj.commands) ? obj.commands.map(String) : void 0,
+      decision,
+      reason: obj.reason ? String(obj.reason) : void 0,
+      allowAll: obj.allowAll === true ? true : void 0
+    };
+    switch (type) {
+      case "path": {
+        const path = String(obj.path || "");
+        if (!path) continue;
+        const policy = { ...base, type: "path", path };
+        if (obj.recursive === false) policy.recursive = false;
+        results.push(policy);
+        break;
+      }
+      case "database": {
+        const host = String(obj.host || "");
+        if (!host) continue;
+        const policy = { ...base, type: "database", host };
+        if (typeof obj.port === "number") policy.port = obj.port;
+        if (obj.database) policy.database = String(obj.database);
+        results.push(policy);
+        break;
+      }
+      case "endpoint": {
+        const pattern = String(obj.pattern || "");
+        if (!pattern) continue;
+        results.push({ ...base, type: "endpoint", pattern });
+        break;
+      }
+      default:
+        process.stderr.write(`[warden] Warning: unknown target policy type "${type}", skipping
+`);
+    }
+  }
+  return results;
+}
+function parseLegacyPaths(raw) {
+  const results = [];
+  for (const e of raw) {
+    if (!e || typeof e !== "object") continue;
+    const obj = e;
+    const decision = String(obj.decision || "allow");
+    if (!isValidDecision(decision)) continue;
+    const path = String(obj.path || "");
+    if (!path) continue;
+    const tp = { type: "path", path, decision };
+    if (obj.recursive === false) tp.recursive = false;
+    if (Array.isArray(obj.commands)) tp.commands = obj.commands.map(String);
+    if (obj.reason) tp.reason = String(obj.reason);
+    results.push(tp);
+  }
+  return results;
+}
+function parseLegacyDatabases(raw) {
+  const results = [];
+  for (const e of raw) {
+    if (!e || typeof e !== "object") continue;
+    const obj = e;
+    const decision = String(obj.decision || "allow");
+    if (!isValidDecision(decision)) continue;
+    const host = String(obj.host || "");
+    if (!host) continue;
+    const td = { type: "database", host, decision };
+    if (typeof obj.port === "number") td.port = obj.port;
+    if (obj.database) td.database = String(obj.database);
+    if (Array.isArray(obj.commands)) td.commands = obj.commands.map(String);
+    if (obj.reason) td.reason = String(obj.reason);
+    results.push(td);
+  }
+  return results;
+}
+function parseLegacyEndpoints(raw) {
+  const results = [];
+  for (const e of raw) {
+    if (!e || typeof e !== "object") continue;
+    const obj = e;
+    const decision = String(obj.decision || "allow");
+    if (!isValidDecision(decision)) continue;
+    const pattern = String(obj.pattern || "");
+    if (!pattern) continue;
+    const te = { type: "endpoint", pattern, decision };
+    if (Array.isArray(obj.commands)) te.commands = obj.commands.map(String);
+    if (obj.reason) te.reason = String(obj.reason);
+    results.push(te);
+  }
+  return results;
+}
+var LEGACY_REMOTE_MAP = {
+  trustedSSHHosts: "ssh",
+  trustedDockerContainers: "docker",
+  trustedKubectlContexts: "kubectl",
+  trustedSprites: "sprite",
+  trustedFlyApps: "fly"
+};
 function mergeNonLayerFields(config, raw) {
-  if (Array.isArray(raw.trustedSSHHosts)) {
-    config.trustedSSHHosts = [...config.trustedSSHHosts || [], ...parseTrustedList(raw.trustedSSHHosts)];
+  if (Array.isArray(raw.trustedRemotes)) {
+    config.trustedRemotes = [...config.trustedRemotes || [], ...parseTrustedRemotes(raw.trustedRemotes)];
   }
-  if (Array.isArray(raw.trustedDockerContainers)) {
-    config.trustedDockerContainers = [...config.trustedDockerContainers || [], ...parseTrustedList(raw.trustedDockerContainers)];
+  if (Array.isArray(raw.targetPolicies)) {
+    config.targetPolicies = [...config.targetPolicies || [], ...parseTargetPolicies(raw.targetPolicies)];
   }
-  if (Array.isArray(raw.trustedKubectlContexts)) {
-    config.trustedKubectlContexts = [...config.trustedKubectlContexts || [], ...parseTrustedList(raw.trustedKubectlContexts)];
+  for (const [key, context] of Object.entries(LEGACY_REMOTE_MAP)) {
+    if (Array.isArray(raw[key])) {
+      const remotes = parseTrustedList(raw[key]).map((t) => ({ ...t, context }));
+      config.trustedRemotes = [...config.trustedRemotes || [], ...remotes];
+    }
   }
-  if (Array.isArray(raw.trustedSprites)) {
-    config.trustedSprites = [...config.trustedSprites || [], ...parseTrustedList(raw.trustedSprites)];
+  if (Array.isArray(raw.trustedPaths)) {
+    config.targetPolicies = [...config.targetPolicies || [], ...parseLegacyPaths(raw.trustedPaths)];
+  }
+  if (Array.isArray(raw.trustedDatabases)) {
+    config.targetPolicies = [...config.targetPolicies || [], ...parseLegacyDatabases(raw.trustedDatabases)];
+  }
+  if (Array.isArray(raw.trustedEndpoints)) {
+    config.targetPolicies = [...config.targetPolicies || [], ...parseLegacyEndpoints(raw.trustedEndpoints)];
   }
   if (typeof raw.defaultDecision === "string") {
     if (isValidDecision(raw.defaultDecision)) {
@@ -20171,7 +20661,7 @@ function parseArgs(argv) {
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--cwd" && argv[i + 1]) {
-      cwd = (0, import_path3.resolve)(argv[i + 1]);
+      cwd = (0, import_path4.resolve)(argv[i + 1]);
       i += 1;
       continue;
     }
@@ -20207,13 +20697,13 @@ function main() {
   const options = parseArgs(process.argv.slice(2));
   const config = loadConfig(options.cwd);
   const rules = generateCodexRules(config);
-  const target = options.outPath ?? (0, import_path3.join)(options.cwd, ".codex", "rules", "warden.rules");
+  const target = options.outPath ?? (0, import_path4.join)(options.cwd, ".codex", "rules", "warden.rules");
   if (target === "-") {
     process.stdout.write(rules);
     return;
   }
-  const resolvedTarget = (0, import_path3.isAbsolute)(target) ? target : (0, import_path3.resolve)(options.cwd, target);
-  (0, import_fs2.mkdirSync)((0, import_path3.dirname)(resolvedTarget), { recursive: true });
+  const resolvedTarget = (0, import_path4.isAbsolute)(target) ? target : (0, import_path4.resolve)(options.cwd, target);
+  (0, import_fs2.mkdirSync)((0, import_path4.dirname)(resolvedTarget), { recursive: true });
   (0, import_fs2.writeFileSync)(resolvedTarget, rules, "utf-8");
   process.stderr.write(`[warden] Wrote Codex rules to ${resolvedTarget}
 `);

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -18456,6 +18456,284 @@ function regexFallbackParse(input) {
 
 // src/evaluator.ts
 var import_os = require("os");
+
+// src/targets.ts
+var import_path2 = require("path");
+
+// src/glob.ts
+function globToRegex(pattern) {
+  let regex = "";
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === "*") {
+      regex += ".*";
+    } else if (ch === "?") {
+      regex += ".";
+    } else if (ch === "[") {
+      i++;
+      if (i < pattern.length && pattern[i] === "!") {
+        regex += "[^";
+        i++;
+      } else {
+        regex += "[";
+      }
+      while (i < pattern.length && pattern[i] !== "]") {
+        regex += pattern[i];
+        i++;
+      }
+      if (i < pattern.length) regex += "]";
+    } else if (ch === "{") {
+      const end = pattern.indexOf("}", i);
+      if (end !== -1) {
+        const alternatives = pattern.slice(i + 1, end).split(",").map((s) => s.replace(/[.+^$|\\()]/g, "\\$&"));
+        regex += `(${alternatives.join("|")})`;
+        i = end;
+      } else {
+        regex += "\\{";
+      }
+    } else if (".+^$|\\()".includes(ch)) {
+      regex += "\\" + ch;
+    } else {
+      regex += ch;
+    }
+    i++;
+  }
+  return new RegExp(`^${regex}$`);
+}
+
+// src/targets.ts
+var PATH_COMMANDS = /* @__PURE__ */ new Set([
+  "rm",
+  "chmod",
+  "chown",
+  "cp",
+  "mv",
+  "tee",
+  "mkdir",
+  "rmdir",
+  "touch",
+  "ln"
+]);
+function evaluatePathTarget(cmd, cwd, targets) {
+  if (targets.length === 0) return null;
+  const positionalArgs = cmd.args.filter((a) => !a.startsWith("-"));
+  if (positionalArgs.length === 0) return null;
+  let bestMatch = null;
+  for (const target of targets) {
+    if (target.allowAll) {
+    } else {
+      if (target.commands && target.commands.length > 0 && !target.commands.includes(cmd.command)) {
+        continue;
+      }
+      if (!target.commands && !PATH_COMMANDS.has(cmd.command)) {
+        continue;
+      }
+    }
+    const targetPath = (0, import_path2.normalize)(target.path.replace(/\{\{cwd\}\}/g, cwd));
+    const recursive = target.recursive !== false;
+    for (const arg of positionalArgs) {
+      const resolvedArg = (0, import_path2.normalize)((0, import_path2.resolve)(cwd, arg));
+      const matches = recursive ? resolvedArg === targetPath || resolvedArg.startsWith(targetPath + "/") : resolvedArg === targetPath;
+      if (matches) {
+        const decision = target.allowAll ? "allow" : target.decision;
+        const detail = {
+          command: cmd.command,
+          args: cmd.args,
+          decision,
+          reason: target.reason || `Path "${resolvedArg}" matches trusted path "${target.path}" (${decision})`,
+          matchedRule: "trustedPaths"
+        };
+        if (decision === "deny") return detail;
+        if (!bestMatch || bestMatch.decision !== "deny") {
+          bestMatch = detail;
+        }
+      }
+    }
+  }
+  return bestMatch;
+}
+var DB_HOST_FLAGS = {
+  psql: ["-h", "--host"],
+  mysql: ["-h", "--host"],
+  mariadb: ["-h", "--host"],
+  "redis-cli": ["-h"],
+  mongosh: ["--host"]
+};
+var DB_DATABASE_FLAGS = {
+  psql: ["-d", "--dbname"],
+  mysql: ["-D", "--database"],
+  mariadb: ["-D", "--database"]
+};
+var DB_PORT_FLAGS = {
+  psql: ["-p", "--port"],
+  mysql: ["-P", "--port"],
+  mariadb: ["-P", "--port"],
+  "redis-cli": ["-p"],
+  mongosh: ["--port"]
+};
+function extractFlagValue(args2, flags) {
+  for (let i = 0; i < args2.length; i++) {
+    const arg = args2[i];
+    for (const f of flags) {
+      if (arg.startsWith(f + "=")) {
+        return arg.slice(f.length + 1);
+      }
+    }
+    if (flags.includes(arg) && i + 1 < args2.length) {
+      return args2[i + 1];
+    }
+  }
+  return void 0;
+}
+function parseDBConnection(cmd) {
+  const command = cmd.command;
+  const info = {};
+  for (const arg of cmd.args) {
+    if (arg.startsWith("postgresql://") || arg.startsWith("postgres://")) {
+      try {
+        const url = new URL(arg);
+        info.host = url.hostname;
+        if (url.port) info.port = parseInt(url.port, 10);
+        if (url.pathname.length > 1) info.database = url.pathname.slice(1);
+        return info;
+      } catch {
+      }
+    }
+    if (arg.startsWith("mongodb://") || arg.startsWith("mongodb+srv://")) {
+      try {
+        const url = new URL(arg);
+        info.host = url.hostname;
+        if (url.port) info.port = parseInt(url.port, 10);
+        if (url.pathname.length > 1) info.database = url.pathname.slice(1);
+        return info;
+      } catch {
+      }
+    }
+  }
+  const hostFlags = DB_HOST_FLAGS[command];
+  if (hostFlags) {
+    const h = extractFlagValue(cmd.args, hostFlags);
+    if (h) info.host = h;
+  }
+  const dbFlags = DB_DATABASE_FLAGS[command];
+  if (dbFlags) {
+    const d = extractFlagValue(cmd.args, dbFlags);
+    if (d) info.database = d;
+  }
+  const portFlags = DB_PORT_FLAGS[command];
+  if (portFlags) {
+    const p = extractFlagValue(cmd.args, portFlags);
+    if (p) info.port = parseInt(p, 10);
+  }
+  return info;
+}
+var DB_COMMANDS = new Set(Object.keys(DB_HOST_FLAGS));
+function evaluateDatabaseTarget(cmd, targets) {
+  if (targets.length === 0) return null;
+  const hasAllowAll = targets.some((t) => t.allowAll);
+  if (!hasAllowAll && !DB_COMMANDS.has(cmd.command)) return null;
+  const applicableTargets = targets.filter((t) => t.allowAll || DB_COMMANDS.has(cmd.command));
+  if (applicableTargets.length === 0) return null;
+  const conn = parseDBConnection(cmd);
+  if (!conn.host) return null;
+  let bestMatch = null;
+  for (const target of applicableTargets) {
+    if (!target.allowAll && target.commands && target.commands.length > 0 && !target.commands.includes(cmd.command)) {
+      continue;
+    }
+    const hostMatch = globToRegex(target.host).test(conn.host);
+    if (!hostMatch) continue;
+    if (target.port !== void 0 && conn.port !== void 0 && target.port !== conn.port) {
+      continue;
+    }
+    if (target.database) {
+      if (!conn.database || !globToRegex(target.database).test(conn.database)) continue;
+    }
+    const decision = target.allowAll ? "allow" : target.decision;
+    const detail = {
+      command: cmd.command,
+      args: cmd.args,
+      decision,
+      reason: target.reason || `Database "${conn.host}${conn.database ? "/" + conn.database : ""}" matches trusted database (${decision})`,
+      matchedRule: "trustedDatabases"
+    };
+    if (decision === "deny") return detail;
+    if (!bestMatch) bestMatch = detail;
+  }
+  return bestMatch;
+}
+var ENDPOINT_COMMANDS = /* @__PURE__ */ new Set(["curl", "wget", "http", "httpie"]);
+function extractURLs(cmd) {
+  const urls = [];
+  const args2 = cmd.args;
+  for (let i = 0; i < args2.length; i++) {
+    const arg = args2[i];
+    if (arg === "--url" && i + 1 < args2.length) {
+      urls.push(args2[i + 1]);
+      i++;
+      continue;
+    }
+    if (arg.startsWith("http://") || arg.startsWith("https://")) {
+      urls.push(arg);
+    }
+  }
+  return urls;
+}
+function evaluateEndpointTarget(cmd, targets) {
+  if (targets.length === 0) return null;
+  const hasAllowAll = targets.some((t) => t.allowAll);
+  if (!hasAllowAll && !ENDPOINT_COMMANDS.has(cmd.command)) return null;
+  const urls = extractURLs(cmd);
+  if (urls.length === 0) return null;
+  let bestMatch = null;
+  for (const target of targets) {
+    if (!target.allowAll && target.commands && target.commands.length > 0 && !target.commands.includes(cmd.command)) {
+      continue;
+    }
+    for (const url of urls) {
+      if (globToRegex(target.pattern).test(url)) {
+        const decision = target.allowAll ? "allow" : target.decision;
+        const detail = {
+          command: cmd.command,
+          args: cmd.args,
+          decision,
+          reason: target.reason || `URL "${url}" matches trusted endpoint "${target.pattern}" (${decision})`,
+          matchedRule: "trustedEndpoints"
+        };
+        if (decision === "deny") return detail;
+        if (!bestMatch) bestMatch = detail;
+      }
+    }
+  }
+  return bestMatch;
+}
+function evaluateTargetPolicies(cmd, cwd, config) {
+  const policies = config.targetPolicies;
+  if (!policies?.length) return null;
+  const results = [];
+  const pathPolicies = policies.filter((p) => p.type === "path");
+  if (pathPolicies.length) {
+    const r = evaluatePathTarget(cmd, cwd, pathPolicies);
+    if (r) results.push(r);
+  }
+  const dbPolicies = policies.filter((p) => p.type === "database");
+  if (dbPolicies.length) {
+    const r = evaluateDatabaseTarget(cmd, dbPolicies);
+    if (r) results.push(r);
+  }
+  const endpointPolicies = policies.filter((p) => p.type === "endpoint");
+  if (endpointPolicies.length) {
+    const r = evaluateEndpointTarget(cmd, endpointPolicies);
+    if (r) results.push(r);
+  }
+  if (results.length === 0) return null;
+  const deny = results.find((r) => r.decision === "deny");
+  if (deny) return deny;
+  return results[0];
+}
+
+// src/evaluator.ts
 function safeRegexTest(pattern, input) {
   try {
     return new RegExp(pattern).test(input);
@@ -18475,7 +18753,9 @@ function commandMatchesName(cmd, name) {
   return cmd.command === name;
 }
 var MAX_RECURSION_DEPTH = 10;
-function evaluate(parsed, config, depth = 0) {
+function evaluate(parsed, config, cwdOrDepth, maybeDepth) {
+  const cwd = typeof cwdOrDepth === "string" ? cwdOrDepth : void 0;
+  const depth = typeof cwdOrDepth === "number" ? cwdOrDepth : maybeDepth ?? 0;
   if (depth > MAX_RECURSION_DEPTH) {
     return { decision: "ask", reason: "Maximum recursion depth exceeded", details: [] };
   }
@@ -18488,7 +18768,7 @@ function evaluate(parsed, config, depth = 0) {
   if (parsed.hasSubshell && parsed.subshellCommands.length > 0) {
     for (const subCmd of parsed.subshellCommands) {
       const subParsed = parseCommand(subCmd);
-      const subResult = evaluate(subParsed, config, depth + 1);
+      const subResult = evaluate(subParsed, config, cwd, depth + 1);
       if (subResult.decision === "deny") {
         return { decision: "deny", reason: `Subshell command: ${subResult.reason}`, details: subResult.details };
       }
@@ -18501,7 +18781,7 @@ function evaluate(parsed, config, depth = 0) {
   }
   const details = [];
   for (const cmd of parsed.commands) {
-    details.push(evaluateCommand(cmd, config, depth));
+    details.push(evaluateCommand(cmd, config, cwd, depth));
   }
   const decisions = details.map((d) => d.decision);
   if (decisions.includes("deny")) {
@@ -18522,7 +18802,7 @@ function evaluate(parsed, config, depth = 0) {
   }
   return { decision: "allow", reason: "All commands are safe", details };
 }
-function evaluateCommand(cmd, config, depth = 0) {
+function evaluateCommand(cmd, config, cwd, depth = 0) {
   const { command, args: args2 } = cmd;
   for (const layer of config.layers) {
     if (layer.alwaysDeny.some((name) => commandMatchesName(cmd, name))) {
@@ -18532,31 +18812,51 @@ function evaluateCommand(cmd, config, depth = 0) {
       return { command, args: args2, decision: "allow", reason: `"${command}" is safe`, matchedRule: "alwaysAllow" };
     }
   }
-  if ((command === "ssh" || command === "scp" || command === "rsync") && config.trustedSSHHosts?.length) {
-    const sshResult = evaluateSSHCommand(cmd, config, depth);
-    if (sshResult) return sshResult;
+  if (cwd) {
+    const targetResult = evaluateTargetPolicies(cmd, cwd, config);
+    if (targetResult) return targetResult;
   }
-  if (command === "docker" && config.trustedDockerContainers?.length) {
-    const dockerResult = evaluateDockerExec(cmd, config, depth);
-    if (dockerResult) return dockerResult;
+  const remotes = config.trustedRemotes || [];
+  if (command === "ssh" || command === "scp" || command === "rsync") {
+    const sshTargets = remotes.filter((r) => r.context === "ssh");
+    if (sshTargets.length) {
+      const sshResult = evaluateSSHCommand(cmd, config, sshTargets, depth);
+      if (sshResult) return sshResult;
+    }
   }
-  if (command === "kubectl" && config.trustedKubectlContexts?.length) {
-    const kubectlResult = evaluateKubectlExec(cmd, config, depth);
-    if (kubectlResult) return kubectlResult;
+  if (command === "docker") {
+    const dockerTargets = remotes.filter((r) => r.context === "docker");
+    if (dockerTargets.length) {
+      const dockerResult = evaluateDockerExec(cmd, config, dockerTargets, depth);
+      if (dockerResult) return dockerResult;
+    }
   }
-  if (command === "sprite" && config.trustedSprites?.length) {
-    const spriteResult = evaluateSpriteExec(cmd, config, depth);
-    if (spriteResult) return spriteResult;
+  if (command === "kubectl") {
+    const kubectlTargets = remotes.filter((r) => r.context === "kubectl");
+    if (kubectlTargets.length) {
+      const kubectlResult = evaluateKubectlExec(cmd, config, kubectlTargets, depth);
+      if (kubectlResult) return kubectlResult;
+    }
   }
-  if ((command === "fly" || command === "flyctl") && config.trustedFlyApps?.length) {
-    const flyResult = evaluateFlyCommand(cmd, config, depth);
-    if (flyResult) return flyResult;
+  if (command === "sprite") {
+    const spriteTargets = remotes.filter((r) => r.context === "sprite");
+    if (spriteTargets.length) {
+      const spriteResult = evaluateSpriteExec(cmd, config, spriteTargets, depth);
+      if (spriteResult) return spriteResult;
+    }
+  }
+  if (command === "fly" || command === "flyctl") {
+    const flyTargets = remotes.filter((r) => r.context === "fly");
+    if (flyTargets.length) {
+      const flyResult = evaluateFlyCommand(cmd, config, flyTargets, depth);
+      if (flyResult) return flyResult;
+    }
   }
   if (command === "xargs") {
-    return evaluateXargsCommand(cmd, config, depth);
+    return evaluateXargsCommand(cmd, config, cwd, depth);
   }
   if (command === "find") {
-    return evaluateFindCommand(cmd, config, depth);
+    return evaluateFindCommand(cmd, config, cwd, depth);
   }
   const mergedRule = collectMergedRule(cmd, config);
   if (mergedRule) {
@@ -18718,7 +19018,7 @@ function parseXargsSubcommand(args2) {
     }
   };
 }
-function evaluateXargsCommand(cmd, config, depth = 0) {
+function evaluateXargsCommand(cmd, config, cwd, depth = 0) {
   const { command, args: args2 } = cmd;
   const { subcommand, unresolved } = parseXargsSubcommand(args2);
   if (unresolved || !subcommand) {
@@ -18742,7 +19042,7 @@ function evaluateXargsCommand(cmd, config, depth = 0) {
   } else {
     parsed = { commands: [subcommand], hasSubshell: false, subshellCommands: [], parseError: false };
   }
-  const result = evaluate(parsed, config, depth + 1);
+  const result = evaluate(parsed, config, cwd, depth + 1);
   return {
     command,
     args: args2,
@@ -18780,7 +19080,7 @@ function parseFindExecCommands(args2) {
   }
   return commands;
 }
-function evaluateFindCommand(cmd, config, depth = 0) {
+function evaluateFindCommand(cmd, config, cwd, depth = 0) {
   const { command, args: args2 } = cmd;
   if (args2.some((a) => a === "-delete")) {
     return { command, args: args2, decision: "ask", reason: "find -delete can remove files", matchedRule: "find:delete" };
@@ -18799,7 +19099,7 @@ function evaluateFindCommand(cmd, config, depth = 0) {
       subshellCommands: [],
       parseError: false
     };
-    const result = evaluate(parsed, config, depth + 1);
+    const result = evaluate(parsed, config, cwd, depth + 1);
     if (result.decision === "deny") {
       return { command, args: args2, decision: "deny", reason: `find -exec: ${result.reason}`, matchedRule: "find:exec" };
     }
@@ -18831,48 +19131,6 @@ var SSH_FLAGS_WITH_VALUE = /* @__PURE__ */ new Set([
   "-W",
   "-w"
 ]);
-function globToRegex(pattern) {
-  let regex = "";
-  let i = 0;
-  while (i < pattern.length) {
-    const ch = pattern[i];
-    if (ch === "*") {
-      regex += ".*";
-    } else if (ch === "?") {
-      regex += ".";
-    } else if (ch === "[") {
-      i++;
-      if (i < pattern.length && pattern[i] === "!") {
-        regex += "[^";
-        i++;
-      } else {
-        regex += "[";
-      }
-      while (i < pattern.length && pattern[i] !== "]") {
-        regex += pattern[i];
-        i++;
-      }
-      if (i < pattern.length) {
-        regex += "]";
-      }
-    } else if (ch === "{") {
-      const end = pattern.indexOf("}", i);
-      if (end !== -1) {
-        const alternatives = pattern.slice(i + 1, end).split(",").map((s) => s.replace(/[.+^$|\\()]/g, "\\$&"));
-        regex += `(${alternatives.join("|")})`;
-        i = end;
-      } else {
-        regex += "\\{";
-      }
-    } else if (".+^$|\\()".includes(ch)) {
-      regex += "\\" + ch;
-    } else {
-      regex += ch;
-    }
-    i++;
-  }
-  return new RegExp(`^${regex}$`);
-}
 function findMatchingTarget(value, targets) {
   return targets.find((t) => globToRegex(t.name).test(value)) || null;
 }
@@ -18913,13 +19171,12 @@ function extractHostFromRemotePath(args2) {
   }
   return null;
 }
-function evaluateSSHCommand(cmd, config, depth = 0) {
+function evaluateSSHCommand(cmd, config, targets, depth = 0) {
   const { command, args: args2 } = cmd;
-  const trustedHosts = config.trustedSSHHosts || [];
   if (command === "scp" || command === "rsync") {
     const host2 = extractHostFromRemotePath(args2);
     if (!host2) return null;
-    const target2 = findMatchingTarget(host2, trustedHosts);
+    const target2 = findMatchingTarget(host2, targets);
     if (!target2) return null;
     if (target2.allowAll || !target2.overrides) {
       return {
@@ -18949,7 +19206,7 @@ function evaluateSSHCommand(cmd, config, depth = 0) {
   }
   const { host, remoteCommand } = parseSSHArgs(args2);
   if (!host) return null;
-  const target = findMatchingTarget(host, trustedHosts);
+  const target = findMatchingTarget(host, targets);
   if (!target) return null;
   if (!remoteCommand) {
     return {
@@ -19058,12 +19315,12 @@ function parseDockerExecArgs(args2) {
   }
   return { target, remoteArgs };
 }
-function evaluateDockerExec(cmd, config, depth = 0) {
+function evaluateDockerExec(cmd, config, targets, depth = 0) {
   const { command, args: args2 } = cmd;
   if (args2[0] !== "exec") return null;
   const { target: containerName, remoteArgs } = parseDockerExecArgs(args2.slice(1));
   if (!containerName) return null;
-  const matched = findMatchingTarget(containerName, config.trustedDockerContainers || []);
+  const matched = findMatchingTarget(containerName, targets);
   if (!matched) return null;
   const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);
   return {
@@ -19138,12 +19395,12 @@ function parseKubectlExecArgs(args2) {
   }
   return { context, pod, remoteArgs };
 }
-function evaluateKubectlExec(cmd, config, depth = 0) {
+function evaluateKubectlExec(cmd, config, targets, depth = 0) {
   const { command, args: args2 } = cmd;
   if (args2[0] !== "exec") return null;
   const { context, pod, remoteArgs } = parseKubectlExecArgs(args2.slice(1));
   if (!context) return null;
-  const matched = findMatchingTarget(context, config.trustedKubectlContexts || []);
+  const matched = findMatchingTarget(context, targets);
   if (!matched) return null;
   const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);
   return {
@@ -19205,11 +19462,11 @@ function parseSpriteExecArgs(args2) {
   }
   return { spriteName, remoteArgs };
 }
-function evaluateSpriteExec(cmd, config, depth = 0) {
+function evaluateSpriteExec(cmd, config, targets, depth = 0) {
   const { command, args: args2 } = cmd;
   const { spriteName, remoteArgs } = parseSpriteExecArgs(args2);
   if (!spriteName) return null;
-  const matched = findMatchingTarget(spriteName, config.trustedSprites || []);
+  const matched = findMatchingTarget(spriteName, targets);
   if (!matched) return null;
   const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);
   return {
@@ -19291,12 +19548,12 @@ function parseFlySSHArgs(args2) {
   }
   return { app, remoteArgs, isSSH: isSSH && foundConsole };
 }
-function evaluateFlyCommand(cmd, config, depth = 0) {
+function evaluateFlyCommand(cmd, config, targets, depth = 0) {
   const { command, args: args2 } = cmd;
   const { app, remoteArgs, isSSH } = parseFlySSHArgs(args2);
   if (!isSSH) return null;
   if (!app) return null;
-  const matched = findMatchingTarget(app, config.trustedFlyApps || []);
+  const matched = findMatchingTarget(app, targets);
   if (!matched) return null;
   const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);
   return {
@@ -19312,7 +19569,7 @@ function evaluateFlyCommand(cmd, config, depth = 0) {
 var import_fs = require("fs");
 var import_yaml = __toESM(require_dist2(), 1);
 var import_os2 = require("os");
-var import_path2 = require("path");
+var import_path3 = require("path");
 
 // src/defaults.ts
 var SAFE_DEV_TOOLS = [
@@ -19460,11 +19717,8 @@ var DEFAULT_CONFIG = {
   askOnSubshell: true,
   notifyOnAsk: true,
   notifyOnDeny: true,
-  trustedSSHHosts: [],
-  trustedDockerContainers: [],
-  trustedKubectlContexts: [],
-  trustedSprites: [],
-  trustedFlyApps: [],
+  trustedRemotes: [],
+  targetPolicies: [],
   layers: [{
     alwaysAllow: [
       // Read-only file operations
@@ -20045,8 +20299,8 @@ function isValidDecision(value) {
   return VALID_DECISIONS.has(value);
 }
 var USER_CONFIG_PATHS = [
-  (0, import_path2.join)((0, import_os2.homedir)(), ".claude", "warden.yaml"),
-  (0, import_path2.join)((0, import_os2.homedir)(), ".claude", "warden.json")
+  (0, import_path3.join)((0, import_os2.homedir)(), ".claude", "warden.yaml"),
+  (0, import_path3.join)((0, import_os2.homedir)(), ".claude", "warden.json")
 ];
 var PROJECT_CONFIG_NAMES = [
   ".claude/warden.yaml",
@@ -20069,7 +20323,7 @@ function loadConfig(cwd) {
   let workspaceRaw = null;
   if (cwd) {
     for (const name of PROJECT_CONFIG_NAMES) {
-      const result = tryLoadFile((0, import_path2.join)(cwd, name));
+      const result = tryLoadFile((0, import_path3.join)(cwd, name));
       if (result) {
         workspaceLayer = extractLayer(result);
         workspaceRaw = result;
@@ -20171,21 +20425,153 @@ function parseTrustedList(raw) {
     return null;
   }).filter((t) => t !== null);
 }
+var VALID_REMOTE_CONTEXTS = /* @__PURE__ */ new Set(["ssh", "docker", "kubectl", "sprite", "fly"]);
+function parseTrustedRemotes(raw) {
+  const results = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const obj = entry;
+    const context = String(obj.context || "");
+    if (!VALID_REMOTE_CONTEXTS.has(context)) {
+      process.stderr.write(`[warden] Warning: unknown remote context "${context}", skipping
+`);
+      continue;
+    }
+    const name = String(obj.name || "");
+    if (!name) continue;
+    const remote = { name, context };
+    if (obj.allowAll === true) remote.allowAll = true;
+    if (obj.overrides && typeof obj.overrides === "object") {
+      remote.overrides = extractLayer(obj.overrides);
+    }
+    results.push(remote);
+  }
+  return results;
+}
+function parseTargetPolicies(raw) {
+  const results = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") continue;
+    const obj = entry;
+    const type = String(obj.type || "");
+    const rawDecision = String(obj.decision || "allow");
+    const decision = isValidDecision(rawDecision) ? rawDecision : "allow";
+    const base = {
+      commands: Array.isArray(obj.commands) ? obj.commands.map(String) : void 0,
+      decision,
+      reason: obj.reason ? String(obj.reason) : void 0,
+      allowAll: obj.allowAll === true ? true : void 0
+    };
+    switch (type) {
+      case "path": {
+        const path = String(obj.path || "");
+        if (!path) continue;
+        const policy = { ...base, type: "path", path };
+        if (obj.recursive === false) policy.recursive = false;
+        results.push(policy);
+        break;
+      }
+      case "database": {
+        const host = String(obj.host || "");
+        if (!host) continue;
+        const policy = { ...base, type: "database", host };
+        if (typeof obj.port === "number") policy.port = obj.port;
+        if (obj.database) policy.database = String(obj.database);
+        results.push(policy);
+        break;
+      }
+      case "endpoint": {
+        const pattern = String(obj.pattern || "");
+        if (!pattern) continue;
+        results.push({ ...base, type: "endpoint", pattern });
+        break;
+      }
+      default:
+        process.stderr.write(`[warden] Warning: unknown target policy type "${type}", skipping
+`);
+    }
+  }
+  return results;
+}
+function parseLegacyPaths(raw) {
+  const results = [];
+  for (const e of raw) {
+    if (!e || typeof e !== "object") continue;
+    const obj = e;
+    const decision = String(obj.decision || "allow");
+    if (!isValidDecision(decision)) continue;
+    const path = String(obj.path || "");
+    if (!path) continue;
+    const tp = { type: "path", path, decision };
+    if (obj.recursive === false) tp.recursive = false;
+    if (Array.isArray(obj.commands)) tp.commands = obj.commands.map(String);
+    if (obj.reason) tp.reason = String(obj.reason);
+    results.push(tp);
+  }
+  return results;
+}
+function parseLegacyDatabases(raw) {
+  const results = [];
+  for (const e of raw) {
+    if (!e || typeof e !== "object") continue;
+    const obj = e;
+    const decision = String(obj.decision || "allow");
+    if (!isValidDecision(decision)) continue;
+    const host = String(obj.host || "");
+    if (!host) continue;
+    const td = { type: "database", host, decision };
+    if (typeof obj.port === "number") td.port = obj.port;
+    if (obj.database) td.database = String(obj.database);
+    if (Array.isArray(obj.commands)) td.commands = obj.commands.map(String);
+    if (obj.reason) td.reason = String(obj.reason);
+    results.push(td);
+  }
+  return results;
+}
+function parseLegacyEndpoints(raw) {
+  const results = [];
+  for (const e of raw) {
+    if (!e || typeof e !== "object") continue;
+    const obj = e;
+    const decision = String(obj.decision || "allow");
+    if (!isValidDecision(decision)) continue;
+    const pattern = String(obj.pattern || "");
+    if (!pattern) continue;
+    const te = { type: "endpoint", pattern, decision };
+    if (Array.isArray(obj.commands)) te.commands = obj.commands.map(String);
+    if (obj.reason) te.reason = String(obj.reason);
+    results.push(te);
+  }
+  return results;
+}
+var LEGACY_REMOTE_MAP = {
+  trustedSSHHosts: "ssh",
+  trustedDockerContainers: "docker",
+  trustedKubectlContexts: "kubectl",
+  trustedSprites: "sprite",
+  trustedFlyApps: "fly"
+};
 function mergeNonLayerFields(config, raw) {
-  if (Array.isArray(raw.trustedSSHHosts)) {
-    config.trustedSSHHosts = [...config.trustedSSHHosts || [], ...parseTrustedList(raw.trustedSSHHosts)];
+  if (Array.isArray(raw.trustedRemotes)) {
+    config.trustedRemotes = [...config.trustedRemotes || [], ...parseTrustedRemotes(raw.trustedRemotes)];
   }
-  if (Array.isArray(raw.trustedDockerContainers)) {
-    config.trustedDockerContainers = [...config.trustedDockerContainers || [], ...parseTrustedList(raw.trustedDockerContainers)];
+  if (Array.isArray(raw.targetPolicies)) {
+    config.targetPolicies = [...config.targetPolicies || [], ...parseTargetPolicies(raw.targetPolicies)];
   }
-  if (Array.isArray(raw.trustedKubectlContexts)) {
-    config.trustedKubectlContexts = [...config.trustedKubectlContexts || [], ...parseTrustedList(raw.trustedKubectlContexts)];
+  for (const [key, context] of Object.entries(LEGACY_REMOTE_MAP)) {
+    if (Array.isArray(raw[key])) {
+      const remotes = parseTrustedList(raw[key]).map((t) => ({ ...t, context }));
+      config.trustedRemotes = [...config.trustedRemotes || [], ...remotes];
+    }
   }
-  if (Array.isArray(raw.trustedSprites)) {
-    config.trustedSprites = [...config.trustedSprites || [], ...parseTrustedList(raw.trustedSprites)];
+  if (Array.isArray(raw.trustedPaths)) {
+    config.targetPolicies = [...config.targetPolicies || [], ...parseLegacyPaths(raw.trustedPaths)];
   }
-  if (Array.isArray(raw.trustedFlyApps)) {
-    config.trustedFlyApps = [...config.trustedFlyApps || [], ...parseTrustedList(raw.trustedFlyApps)];
+  if (Array.isArray(raw.trustedDatabases)) {
+    config.targetPolicies = [...config.targetPolicies || [], ...parseLegacyDatabases(raw.trustedDatabases)];
+  }
+  if (Array.isArray(raw.trustedEndpoints)) {
+    config.targetPolicies = [...config.targetPolicies || [], ...parseLegacyEndpoints(raw.trustedEndpoints)];
   }
   if (typeof raw.defaultDecision === "string") {
     if (isValidDecision(raw.defaultDecision)) {
@@ -20354,9 +20740,9 @@ function sendNotification(title, message, config) {
 // src/yolo.ts
 var import_fs2 = require("fs");
 var import_os3 = require("os");
-var import_path3 = require("path");
+var import_path4 = require("path");
 function yoloFilePath(sessionId) {
-  return (0, import_path3.join)((0, import_os3.tmpdir)(), `claude-warden-yolo-${sessionId}`);
+  return (0, import_path4.join)((0, import_os3.tmpdir)(), `claude-warden-yolo-${sessionId}`);
 }
 function getYoloState(sessionId) {
   const filePath = yoloFilePath(sessionId);
@@ -20487,7 +20873,7 @@ async function main() {
   const yoloState = getYoloState(input.session_id);
   if (yoloState) {
     const parsed2 = parseCommand(command);
-    const result2 = evaluate(parsed2, config);
+    const result2 = evaluate(parsed2, config, input.cwd);
     if (result2.decision === "deny" && !yoloState.bypassDeny) {
     } else {
       const expiryInfo = yoloState.expiresAt ? `expires ${new Date(yoloState.expiresAt).toLocaleTimeString()}` : "full session";

--- a/src/__tests__/evaluator.test.ts
+++ b/src/__tests__/evaluator.test.ts
@@ -2,10 +2,14 @@ import { describe, it, expect } from 'vitest';
 import { evaluate } from '../evaluator';
 import { parseCommand } from '../parser';
 import { DEFAULT_CONFIG } from '../defaults';
-import type { WardenConfig, ConfigLayer, TrustedTarget } from '../types';
+import type { WardenConfig, ConfigLayer, TrustedTarget, TrustedRemote, RemoteContext } from '../types';
 
 function toTargets(items: (string | TrustedTarget)[]): TrustedTarget[] {
   return items.map(i => typeof i === 'string' ? { name: i } : i);
+}
+
+function toRemotes(items: (string | TrustedTarget)[], context: RemoteContext): TrustedRemote[] {
+  return toTargets(items).map(t => ({ ...t, context }));
 }
 
 function eval_(cmd: string) {
@@ -18,7 +22,7 @@ function evalWith(cmd: string, overrides: Partial<WardenConfig>) {
 }
 
 function evalWithSSH(cmd: string, trustedHosts: (string | TrustedTarget)[]) {
-  return evalWith(cmd, { trustedSSHHosts: toTargets(trustedHosts) });
+  return evalWith(cmd, { trustedRemotes: toRemotes(trustedHosts, 'ssh') });
 }
 
 describe('evaluator', () => {
@@ -319,30 +323,30 @@ describe('evaluator', () => {
     });
 
     it('matches ? glob pattern (single char)', () => {
-      expect(evalWith('ssh dev?', { trustedSSHHosts: toTargets(['dev?']) }).decision).toBe('allow');
-      expect(evalWith('ssh devAB', { trustedSSHHosts: toTargets(['dev?']) }).decision).toBe('ask');
+      expect(evalWith('ssh dev?', { trustedRemotes: toRemotes(['dev?'], 'ssh') }).decision).toBe('allow');
+      expect(evalWith('ssh devAB', { trustedRemotes: toRemotes(['dev?'], 'ssh') }).decision).toBe('ask');
     });
 
     it('matches [...] character class', () => {
-      expect(evalWith('ssh dev1', { trustedSSHHosts: toTargets(['dev[123]']) }).decision).toBe('allow');
-      expect(evalWith('ssh dev4', { trustedSSHHosts: toTargets(['dev[123]']) }).decision).toBe('ask');
+      expect(evalWith('ssh dev1', { trustedRemotes: toRemotes(['dev[123]'], 'ssh') }).decision).toBe('allow');
+      expect(evalWith('ssh dev4', { trustedRemotes: toRemotes(['dev[123]'], 'ssh') }).decision).toBe('ask');
     });
 
     it('matches [!...] negated character class', () => {
-      expect(evalWith('ssh devX', { trustedSSHHosts: toTargets(['dev[!0-9]']) }).decision).toBe('allow');
-      expect(evalWith('ssh dev5', { trustedSSHHosts: toTargets(['dev[!0-9]']) }).decision).toBe('ask');
+      expect(evalWith('ssh devX', { trustedRemotes: toRemotes(['dev[!0-9]'], 'ssh') }).decision).toBe('allow');
+      expect(evalWith('ssh dev5', { trustedRemotes: toRemotes(['dev[!0-9]'], 'ssh') }).decision).toBe('ask');
     });
 
     it('matches {a,b,c} brace expansion', () => {
-      expect(evalWith('ssh staging', { trustedSSHHosts: toTargets(['{staging,prod}']) }).decision).toBe('allow');
-      expect(evalWith('ssh prod', { trustedSSHHosts: toTargets(['{staging,prod}']) }).decision).toBe('allow');
-      expect(evalWith('ssh dev', { trustedSSHHosts: toTargets(['{staging,prod}']) }).decision).toBe('ask');
+      expect(evalWith('ssh staging', { trustedRemotes: toRemotes(['{staging,prod}'], 'ssh') }).decision).toBe('allow');
+      expect(evalWith('ssh prod', { trustedRemotes: toRemotes(['{staging,prod}'], 'ssh') }).decision).toBe('allow');
+      expect(evalWith('ssh dev', { trustedRemotes: toRemotes(['{staging,prod}'], 'ssh') }).decision).toBe('ask');
     });
 
     it('matches combined glob features', () => {
-      expect(evalWith('ssh web-staging-01', { trustedSSHHosts: toTargets(['{web,api}-*-[0-9][0-9]']) }).decision).toBe('allow');
-      expect(evalWith('ssh api-prod-99', { trustedSSHHosts: toTargets(['{web,api}-*-[0-9][0-9]']) }).decision).toBe('allow');
-      expect(evalWith('ssh db-staging-01', { trustedSSHHosts: toTargets(['{web,api}-*-[0-9][0-9]']) }).decision).toBe('ask');
+      expect(evalWith('ssh web-staging-01', { trustedRemotes: toRemotes(['{web,api}-*-[0-9][0-9]'], 'ssh') }).decision).toBe('allow');
+      expect(evalWith('ssh api-prod-99', { trustedRemotes: toRemotes(['{web,api}-*-[0-9][0-9]'], 'ssh') }).decision).toBe('allow');
+      expect(evalWith('ssh db-staging-01', { trustedRemotes: toRemotes(['{web,api}-*-[0-9][0-9]'], 'ssh') }).decision).toBe('ask');
     });
 
     it('skips SSH flags correctly', () => {
@@ -390,56 +394,56 @@ describe('evaluator', () => {
     const containers = ['my-app', 'dev-*'];
 
     it('allows docker exec on trusted container', () => {
-      expect(evalWith('docker exec my-app ls', { trustedDockerContainers: toTargets(containers) }).decision).toBe('allow');
+      expect(evalWith('docker exec my-app ls', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('allow');
     });
 
     it('allows docker exec with flags on trusted container', () => {
-      expect(evalWith('docker exec -it my-app ls', { trustedDockerContainers: toTargets(containers) }).decision).toBe('allow');
+      expect(evalWith('docker exec -it my-app ls', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('allow');
     });
 
     it('allows docker exec interactive (no command) on trusted container', () => {
-      expect(evalWith('docker exec -it my-app', { trustedDockerContainers: toTargets(containers) }).decision).toBe('allow');
+      expect(evalWith('docker exec -it my-app', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('allow');
     });
 
     it('denies docker exec with dangerous command on trusted container', () => {
-      expect(evalWith('docker exec my-app sudo rm -rf /', { trustedDockerContainers: toTargets(containers) }).decision).toBe('deny');
+      expect(evalWith('docker exec my-app sudo rm -rf /', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('deny');
     });
 
     it('asks for docker exec on untrusted container', () => {
-      expect(evalWith('docker exec unknown-app ls', { trustedDockerContainers: toTargets(containers) }).decision).toBe('ask');
+      expect(evalWith('docker exec unknown-app ls', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('ask');
     });
 
     it('matches glob patterns for containers', () => {
-      expect(evalWith('docker exec dev-web ls', { trustedDockerContainers: toTargets(containers) }).decision).toBe('allow');
+      expect(evalWith('docker exec dev-web ls', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('allow');
     });
 
     it('does not intercept non-exec docker commands', () => {
-      expect(evalWith('docker ps', { trustedDockerContainers: toTargets(containers) }).decision).toBe('allow');
-      expect(evalWith('docker run ubuntu', { trustedDockerContainers: toTargets(containers) }).decision).toBe('ask');
+      expect(evalWith('docker ps', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('allow');
+      expect(evalWith('docker run ubuntu', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('ask');
     });
 
     it('skips docker exec flags with values', () => {
-      expect(evalWith('docker exec -e FOO=bar -u root my-app cat /etc/hosts', { trustedDockerContainers: toTargets(containers) }).decision).toBe('allow');
+      expect(evalWith('docker exec -e FOO=bar -u root my-app cat /etc/hosts', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('allow');
     });
 
     it('allows bare bash on trusted container (interactive shell)', () => {
-      expect(evalWith('docker exec -it my-app bash', { trustedDockerContainers: toTargets(containers) }).decision).toBe('allow');
+      expect(evalWith('docker exec -it my-app bash', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('allow');
     });
 
     it('allows bare sh on trusted container (interactive shell)', () => {
-      expect(evalWith('docker exec my-app sh', { trustedDockerContainers: toTargets(containers) }).decision).toBe('allow');
+      expect(evalWith('docker exec my-app sh', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('allow');
     });
 
     it('allows bash -c with safe command on trusted container', () => {
-      expect(evalWith('docker exec my-app bash -c "ls -la"', { trustedDockerContainers: toTargets(containers) }).decision).toBe('allow');
+      expect(evalWith('docker exec my-app bash -c "ls -la"', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('allow');
     });
 
     it('denies bash -c with dangerous command on trusted container', () => {
-      expect(evalWith('docker exec my-app bash -c "sudo rm -rf /"', { trustedDockerContainers: toTargets(containers) }).decision).toBe('deny');
+      expect(evalWith('docker exec my-app bash -c "sudo rm -rf /"', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('deny');
     });
 
     it('allows bash -c with piped safe commands on trusted container', () => {
-      expect(evalWith(`docker exec my-app bash -c 'tail -100 /tmp/app.log | grep error | tail -20'`, { trustedDockerContainers: toTargets(containers) }).decision).toBe('allow');
+      expect(evalWith(`docker exec my-app bash -c 'tail -100 /tmp/app.log | grep error | tail -20'`, { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('allow');
     });
   });
 
@@ -447,60 +451,60 @@ describe('evaluator', () => {
     const contexts = ['minikube', 'dev-*'];
 
     it('allows kubectl exec on trusted context with safe command', () => {
-      expect(evalWith('kubectl exec --context minikube my-pod -- cat /etc/hosts', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('allow');
+      expect(evalWith('kubectl exec --context minikube my-pod -- cat /etc/hosts', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('allow');
     });
 
     it('allows kubectl exec interactive on trusted context', () => {
-      expect(evalWith('kubectl exec --context minikube -it my-pod', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('allow');
+      expect(evalWith('kubectl exec --context minikube -it my-pod', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('allow');
     });
 
     it('denies kubectl exec with dangerous command on trusted context', () => {
-      expect(evalWith('kubectl exec --context minikube my-pod -- sudo rm -rf /', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('deny');
+      expect(evalWith('kubectl exec --context minikube my-pod -- sudo rm -rf /', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('deny');
     });
 
     it('asks for kubectl exec without context', () => {
-      expect(evalWith('kubectl exec my-pod -- ls', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('ask');
+      expect(evalWith('kubectl exec my-pod -- ls', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('ask');
     });
 
     it('asks for kubectl exec on untrusted context', () => {
-      expect(evalWith('kubectl exec --context production my-pod -- ls', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('ask');
+      expect(evalWith('kubectl exec --context production my-pod -- ls', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('ask');
     });
 
     it('matches glob patterns for contexts', () => {
-      expect(evalWith('kubectl exec --context dev-cluster my-pod -- ls', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('allow');
+      expect(evalWith('kubectl exec --context dev-cluster my-pod -- ls', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('allow');
     });
 
     it('handles --context=value syntax', () => {
-      expect(evalWith('kubectl exec --context=minikube my-pod -- ls', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('allow');
+      expect(evalWith('kubectl exec --context=minikube my-pod -- ls', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('allow');
     });
 
     it('does not intercept non-exec kubectl commands', () => {
       // 'get' is now always allowed as a read-only kubectl command, so test with a non-read-only subcommand
-      expect(evalWith('kubectl apply -f deployment.yaml --context minikube', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('ask');
+      expect(evalWith('kubectl apply -f deployment.yaml --context minikube', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('ask');
     });
 
     it('handles namespace and container flags', () => {
-      expect(evalWith('kubectl exec --context minikube -n default -c app my-pod -- cat /tmp/log', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('allow');
+      expect(evalWith('kubectl exec --context minikube -n default -c app my-pod -- cat /tmp/log', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('allow');
     });
 
     it('allows bare bash on trusted context (interactive shell)', () => {
-      expect(evalWith('kubectl exec --context minikube my-pod -- bash', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('allow');
+      expect(evalWith('kubectl exec --context minikube my-pod -- bash', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('allow');
     });
 
     it('allows bare sh on trusted context (interactive shell)', () => {
-      expect(evalWith('kubectl exec --context minikube my-pod -- sh', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('allow');
+      expect(evalWith('kubectl exec --context minikube my-pod -- sh', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('allow');
     });
 
     it('allows bash -c with safe command on trusted context', () => {
-      expect(evalWith('kubectl exec --context minikube my-pod -- bash -c "ls -la"', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('allow');
+      expect(evalWith('kubectl exec --context minikube my-pod -- bash -c "ls -la"', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('allow');
     });
 
     it('denies bash -c with dangerous command on trusted context', () => {
-      expect(evalWith('kubectl exec --context minikube my-pod -- bash -c "sudo rm -rf /"', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('deny');
+      expect(evalWith('kubectl exec --context minikube my-pod -- bash -c "sudo rm -rf /"', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('deny');
     });
 
     it('allows bash -c with piped safe commands on trusted context', () => {
-      expect(evalWith(`kubectl exec --context minikube my-pod -- bash -c 'tail -100 /tmp/app.log | grep error | tail -20'`, { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('allow');
+      expect(evalWith(`kubectl exec --context minikube my-pod -- bash -c 'tail -100 /tmp/app.log | grep error | tail -20'`, { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('allow');
     });
   });
 
@@ -508,67 +512,67 @@ describe('evaluator', () => {
     const sprites = ['my-sprite', 'dev-*'];
 
     it('allows sprite exec on trusted sprite', () => {
-      expect(evalWith('sprite exec -s my-sprite ls -la', { trustedSprites: toTargets(sprites) }).decision).toBe('allow');
+      expect(evalWith('sprite exec -s my-sprite ls -la', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('allow');
     });
 
     it('allows sprite x (alias) on trusted sprite', () => {
-      expect(evalWith('sprite x -s my-sprite ls', { trustedSprites: toTargets(sprites) }).decision).toBe('allow');
+      expect(evalWith('sprite x -s my-sprite ls', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('allow');
     });
 
     it('allows sprite console on trusted sprite', () => {
-      expect(evalWith('sprite console -s my-sprite', { trustedSprites: toTargets(sprites) }).decision).toBe('allow');
+      expect(evalWith('sprite console -s my-sprite', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('allow');
     });
 
     it('allows sprite c (alias) on trusted sprite', () => {
-      expect(evalWith('sprite c -s my-sprite', { trustedSprites: toTargets(sprites) }).decision).toBe('allow');
+      expect(evalWith('sprite c -s my-sprite', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('allow');
     });
 
     it('denies sprite exec with dangerous command on trusted sprite', () => {
-      expect(evalWith('sprite exec -s my-sprite sudo rm -rf /', { trustedSprites: toTargets(sprites) }).decision).toBe('deny');
+      expect(evalWith('sprite exec -s my-sprite sudo rm -rf /', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('deny');
     });
 
     it('asks for sprite exec on untrusted sprite', () => {
-      expect(evalWith('sprite exec -s unknown-sprite ls', { trustedSprites: toTargets(sprites) }).decision).toBe('ask');
+      expect(evalWith('sprite exec -s unknown-sprite ls', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('ask');
     });
 
     it('matches glob patterns', () => {
-      expect(evalWith('sprite exec -s dev-web ls', { trustedSprites: toTargets(sprites) }).decision).toBe('allow');
+      expect(evalWith('sprite exec -s dev-web ls', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('allow');
     });
 
     it('handles -o and -s flags before subcommand', () => {
-      expect(evalWith('sprite -o myorg -s my-sprite exec ls', { trustedSprites: toTargets(sprites) }).decision).toBe('allow');
+      expect(evalWith('sprite -o myorg -s my-sprite exec ls', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('allow');
     });
 
     it('handles --sprite=value syntax', () => {
-      expect(evalWith('sprite exec --sprite=my-sprite ls', { trustedSprites: toTargets(sprites) }).decision).toBe('allow');
+      expect(evalWith('sprite exec --sprite=my-sprite ls', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('allow');
     });
 
     it('handles -o and -s with exec subcommand and command', () => {
-      expect(evalWith('sprite exec -o myorg -s my-sprite npm start', { trustedSprites: toTargets(sprites) }).decision).toBe('allow');
+      expect(evalWith('sprite exec -o myorg -s my-sprite npm start', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('allow');
     });
 
     it('recursively evaluates ask-level remote commands', () => {
-      expect(evalWith('sprite exec -s my-sprite node script.js', { trustedSprites: toTargets(sprites) }).decision).toBe('ask');
+      expect(evalWith('sprite exec -s my-sprite node script.js', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('ask');
     });
 
     it('allows bare bash on trusted sprite (interactive shell)', () => {
-      expect(evalWith('sprite exec -s my-sprite bash', { trustedSprites: toTargets(sprites) }).decision).toBe('allow');
+      expect(evalWith('sprite exec -s my-sprite bash', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('allow');
     });
 
     it('allows bare sh on trusted sprite (interactive shell)', () => {
-      expect(evalWith('sprite exec -s my-sprite sh', { trustedSprites: toTargets(sprites) }).decision).toBe('allow');
+      expect(evalWith('sprite exec -s my-sprite sh', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('allow');
     });
 
     it('allows bash -c with safe command on trusted sprite', () => {
-      expect(evalWith('sprite exec -s my-sprite bash -c "ls -la"', { trustedSprites: toTargets(sprites) }).decision).toBe('allow');
+      expect(evalWith('sprite exec -s my-sprite bash -c "ls -la"', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('allow');
     });
 
     it('denies bash -c with dangerous command on trusted sprite', () => {
-      expect(evalWith('sprite exec -s my-sprite bash -c "sudo rm -rf /"', { trustedSprites: toTargets(sprites) }).decision).toBe('deny');
+      expect(evalWith('sprite exec -s my-sprite bash -c "sudo rm -rf /"', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('deny');
     });
 
     it('allows bash -c with piped safe commands on trusted sprite', () => {
-      expect(evalWith(`sprite exec -s my-sprite bash -c 'tail -100 /tmp/app.log | grep error | tail -20'`, { trustedSprites: toTargets(sprites) }).decision).toBe('allow');
+      expect(evalWith(`sprite exec -s my-sprite bash -c 'tail -100 /tmp/app.log | grep error | tail -20'`, { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('allow');
     });
   });
 
@@ -581,7 +585,7 @@ describe('evaluator', () => {
 
     it('allows sudo inside trusted docker container with override', () => {
       expect(evalWith('docker exec my-app sudo apt install curl', {
-        trustedDockerContainers: toTargets(['my-app']),
+        trustedRemotes: toRemotes(['my-app'], 'docker'),
         trustedContextOverrides: overrides,
       }).decision).toBe('allow');
     });
@@ -594,49 +598,49 @@ describe('evaluator', () => {
 
     it('allows sudo inside trusted kubectl context with override', () => {
       expect(evalWith('kubectl exec --context minikube my-pod -- sudo apt install curl', {
-        trustedKubectlContexts: toTargets(['minikube']),
+        trustedRemotes: toRemotes(['minikube'], 'kubectl'),
         trustedContextOverrides: overrides,
       }).decision).toBe('allow');
     });
 
     it('allows sudo inside trusted SSH host with override', () => {
       expect(evalWith('ssh devserver sudo apt install curl', {
-        trustedSSHHosts: toTargets(['devserver']),
+        trustedRemotes: toRemotes(['devserver'], 'ssh'),
         trustedContextOverrides: overrides,
       }).decision).toBe('allow');
     });
 
     it('allows sudo inside trusted sprite with override', () => {
       expect(evalWith('sprite exec -s my-sprite sudo apt install curl', {
-        trustedSprites: toTargets(['my-sprite']),
+        trustedRemotes: toRemotes(['my-sprite'], 'sprite'),
         trustedContextOverrides: overrides,
       }).decision).toBe('allow');
     });
 
     it('allows sudo via bash -c inside trusted docker with override', () => {
       expect(evalWith('docker exec my-app bash -c "sudo apt install curl"', {
-        trustedDockerContainers: toTargets(['my-app']),
+        trustedRemotes: toRemotes(['my-app'], 'docker'),
         trustedContextOverrides: overrides,
       }).decision).toBe('allow');
     });
 
     it('still denies non-overridden dangerous commands in remote context', () => {
       expect(evalWith('docker exec my-app shutdown now', {
-        trustedDockerContainers: toTargets(['my-app']),
+        trustedRemotes: toRemotes(['my-app'], 'docker'),
         trustedContextOverrides: overrides,
       }).decision).toBe('deny');
     });
 
     it('does not apply overrides to untrusted containers', () => {
       expect(evalWith('docker exec unknown-app sudo apt install curl', {
-        trustedDockerContainers: toTargets(['my-app']),
+        trustedRemotes: toRemotes(['my-app'], 'docker'),
         trustedContextOverrides: overrides,
       }).decision).toBe('ask');
     });
 
     it('supports alwaysDeny in context overrides', () => {
       expect(evalWith('docker exec my-app curl http://example.com', {
-        trustedDockerContainers: toTargets(['my-app']),
+        trustedRemotes: toRemotes(['my-app'], 'docker'),
         trustedContextOverrides: { alwaysAllow: [], alwaysDeny: ['curl'], rules: [] },
       }).decision).toBe('deny');
     });
@@ -645,82 +649,82 @@ describe('evaluator', () => {
   describe('per-target trusted overrides', () => {
     it('allowAll on docker container allows sudo, shutdown, etc.', () => {
       expect(evalWith('docker exec dev-box sudo rm -rf /', {
-        trustedDockerContainers: [{ name: 'dev-box', allowAll: true }],
+        trustedRemotes: [{ name: 'dev-box', allowAll: true, context: 'docker' }],
       }).decision).toBe('allow');
     });
 
     it('allowAll on docker container allows shutdown', () => {
       expect(evalWith('docker exec dev-box shutdown now', {
-        trustedDockerContainers: [{ name: 'dev-box', allowAll: true }],
+        trustedRemotes: [{ name: 'dev-box', allowAll: true, context: 'docker' }],
       }).decision).toBe('allow');
     });
 
     it('allowAll on sprite allows everything', () => {
       expect(evalWith('sprite exec -s yudu-claw sudo apt install curl', {
-        trustedSprites: [{ name: 'yudu-claw', allowAll: true }],
+        trustedRemotes: [{ name: 'yudu-claw', allowAll: true, context: 'sprite' }],
       }).decision).toBe('allow');
     });
 
     it('allowAll on SSH host allows everything', () => {
       expect(evalWith('ssh devserver sudo rm -rf /', {
-        trustedSSHHosts: [{ name: 'devserver', allowAll: true }],
+        trustedRemotes: [{ name: 'devserver', allowAll: true, context: 'ssh' }],
       }).decision).toBe('allow');
     });
 
     it('allowAll on kubectl context allows everything', () => {
       expect(evalWith('kubectl exec --context minikube my-pod -- sudo rm -rf /', {
-        trustedKubectlContexts: [{ name: 'minikube', allowAll: true }],
+        trustedRemotes: [{ name: 'minikube', allowAll: true, context: 'kubectl' }],
       }).decision).toBe('allow');
     });
 
     it('per-target overrides allow sudo but global does not', () => {
       expect(evalWith('docker exec dev-box sudo apt install curl', {
-        trustedDockerContainers: [{ name: 'dev-box', overrides: { alwaysAllow: ['sudo', 'apt'], alwaysDeny: [], rules: [] } }],
+        trustedRemotes: [{ name: 'dev-box', overrides: { alwaysAllow: ['sudo', 'apt'], alwaysDeny: [], rules: [] }, context: 'docker' }],
       }).decision).toBe('allow');
     });
 
     it('per-target overrides do not affect other containers', () => {
       expect(evalWith('docker exec other-box sudo apt install curl', {
-        trustedDockerContainers: [
-          { name: 'dev-box', overrides: { alwaysAllow: ['sudo'], alwaysDeny: [], rules: [] } },
-          { name: 'other-box' },
+        trustedRemotes: [
+          { name: 'dev-box', overrides: { alwaysAllow: ['sudo'], alwaysDeny: [], rules: [] }, context: 'docker' },
+          { name: 'other-box', context: 'docker' },
         ],
       }).decision).toBe('deny');
     });
 
     it('per-target overrides combine with global overrides', () => {
       expect(evalWith('docker exec dev-box sudo systemctl restart app', {
-        trustedDockerContainers: [{ name: 'dev-box', overrides: { alwaysAllow: ['sudo'], alwaysDeny: [], rules: [] } }],
+        trustedRemotes: [{ name: 'dev-box', overrides: { alwaysAllow: ['sudo'], alwaysDeny: [], rules: [] }, context: 'docker' }],
         trustedContextOverrides: { alwaysAllow: ['systemctl'], alwaysDeny: [], rules: [] },
       }).decision).toBe('allow');
     });
 
     it('per-target overrides take priority over global overrides', () => {
       expect(evalWith('docker exec dev-box curl http://example.com', {
-        trustedDockerContainers: [{ name: 'dev-box', overrides: { alwaysAllow: [], alwaysDeny: ['curl'], rules: [] } }],
+        trustedRemotes: [{ name: 'dev-box', overrides: { alwaysAllow: [], alwaysDeny: ['curl'], rules: [] }, context: 'docker' }],
         trustedContextOverrides: { alwaysAllow: ['curl'], alwaysDeny: [], rules: [] },
       }).decision).toBe('deny');
     });
 
     it('string entries still work as before (backward compat)', () => {
       expect(evalWith('docker exec my-app ls', {
-        trustedDockerContainers: toTargets(['my-app']),
+        trustedRemotes: toRemotes(['my-app'], 'docker'),
       }).decision).toBe('allow');
     });
 
     it('mixed string and object entries work together', () => {
       const result1 = evalWith('docker exec my-app sudo apt install curl', {
-        trustedDockerContainers: [
-          { name: 'my-app' },
-          { name: 'dev-box', allowAll: true },
+        trustedRemotes: [
+          { name: 'my-app', context: 'docker' },
+          { name: 'dev-box', allowAll: true, context: 'docker' },
         ],
       });
       expect(result1.decision).toBe('deny'); // my-app has no overrides, sudo denied
 
       const result2 = evalWith('docker exec dev-box sudo apt install curl', {
-        trustedDockerContainers: [
-          { name: 'my-app' },
-          { name: 'dev-box', allowAll: true },
+        trustedRemotes: [
+          { name: 'my-app', context: 'docker' },
+          { name: 'dev-box', allowAll: true, context: 'docker' },
         ],
       });
       expect(result2.decision).toBe('allow'); // dev-box has allowAll
@@ -728,31 +732,31 @@ describe('evaluator', () => {
 
     it('allowAll on untrusted target has no effect', () => {
       expect(evalWith('docker exec unknown-box sudo ls', {
-        trustedDockerContainers: [{ name: 'dev-box', allowAll: true }],
+        trustedRemotes: [{ name: 'dev-box', allowAll: true, context: 'docker' }],
       }).decision).toBe('ask');
     });
 
     it('SSH with per-host overrides', () => {
       expect(evalWith('ssh staging-web systemctl restart app', {
-        trustedSSHHosts: [{ name: 'staging-*', overrides: { alwaysAllow: ['systemctl'], alwaysDeny: [], rules: [] } }],
+        trustedRemotes: [{ name: 'staging-*', overrides: { alwaysAllow: ['systemctl'], alwaysDeny: [], rules: [] }, context: 'ssh' }],
       }).decision).toBe('allow');
     });
 
     it('kubectl with per-context overrides', () => {
       expect(evalWith('kubectl exec --context prod-cluster my-pod -- rm -rf /tmp/cache', {
-        trustedKubectlContexts: [{ name: 'prod-cluster', overrides: { alwaysAllow: [], alwaysDeny: ['rm'], rules: [] } }],
+        trustedRemotes: [{ name: 'prod-cluster', overrides: { alwaysAllow: [], alwaysDeny: ['rm'], rules: [] }, context: 'kubectl' }],
       }).decision).toBe('deny');
     });
 
     it('sprite with per-sprite overrides', () => {
       expect(evalWith('sprite exec -s dev-sprite sudo apt install vim', {
-        trustedSprites: [{ name: 'dev-*', overrides: { alwaysAllow: ['sudo', 'apt'], alwaysDeny: [], rules: [] } }],
+        trustedRemotes: [{ name: 'dev-*', overrides: { alwaysAllow: ['sudo', 'apt'], alwaysDeny: [], rules: [] }, context: 'sprite' }],
       }).decision).toBe('allow');
     });
 
     it('allowAll on glob-matched sprite', () => {
       expect(evalWith('sprite exec -s dev-testing sudo shutdown now', {
-        trustedSprites: [{ name: 'dev-*', allowAll: true }],
+        trustedRemotes: [{ name: 'dev-*', allowAll: true, context: 'sprite' }],
       }).decision).toBe('allow');
     });
   });
@@ -999,24 +1003,24 @@ describe('evaluator', () => {
   describe('rsync/scp trusted host overrides', () => {
     it('allows scp to trusted host with allowAll', () => {
       const result = evalWith('scp file.txt user@myhost:/tmp/', {
-        trustedSSHHosts: toTargets([{ name: 'myhost', allowAll: true }]),
+        trustedRemotes: toRemotes([{ name: 'myhost', allowAll: true }], 'ssh'),
       });
       expect(result.decision).toBe('allow');
     });
 
     it('allows rsync to trusted host without overrides', () => {
       const result = evalWith('rsync -av dir/ user@myhost:/tmp/', {
-        trustedSSHHosts: toTargets(['myhost']),
+        trustedRemotes: toRemotes(['myhost'], 'ssh'),
       });
       expect(result.decision).toBe('allow');
     });
 
     it('denies scp when overrides block it', () => {
       const result = evalWith('scp file.txt user@myhost:/tmp/', {
-        trustedSSHHosts: toTargets([{
+        trustedRemotes: toRemotes([{
           name: 'myhost',
           overrides: { alwaysAllow: [], alwaysDeny: ['scp'], rules: [] },
-        }]),
+        }], 'ssh'),
       });
       expect(result.decision).toBe('deny');
     });
@@ -1026,65 +1030,65 @@ describe('evaluator', () => {
     const apps = ['my-app', 'staging-*'];
 
     it('allows fly ssh console with safe command on trusted app', () => {
-      expect(evalWith('fly ssh console -a my-app -C "ls -la"', { trustedFlyApps: toTargets(apps) }).decision).toBe('allow');
+      expect(evalWith('fly ssh console -a my-app -C "ls -la"', { trustedRemotes: toRemotes(apps, 'fly') }).decision).toBe('allow');
     });
 
     it('allows fly ssh console interactive (no command)', () => {
-      expect(evalWith('fly ssh console -a my-app', { trustedFlyApps: toTargets(apps) }).decision).toBe('allow');
+      expect(evalWith('fly ssh console -a my-app', { trustedRemotes: toRemotes(apps, 'fly') }).decision).toBe('allow');
     });
 
     it('allows --app=value syntax', () => {
-      expect(evalWith('fly ssh console --app=my-app -C "ls -la"', { trustedFlyApps: toTargets(apps) }).decision).toBe('allow');
+      expect(evalWith('fly ssh console --app=my-app -C "ls -la"', { trustedRemotes: toRemotes(apps, 'fly') }).decision).toBe('allow');
     });
 
     it('denies fly ssh console with dangerous command on trusted app', () => {
-      expect(evalWith('fly ssh console -a my-app -C "sudo rm -rf /"', { trustedFlyApps: toTargets(apps) }).decision).toBe('deny');
+      expect(evalWith('fly ssh console -a my-app -C "sudo rm -rf /"', { trustedRemotes: toRemotes(apps, 'fly') }).decision).toBe('deny');
     });
 
     it('asks for untrusted app', () => {
-      expect(evalWith('fly ssh console -a unknown-app -C "ls"', { trustedFlyApps: toTargets(apps) }).decision).toBe('ask');
+      expect(evalWith('fly ssh console -a unknown-app -C "ls"', { trustedRemotes: toRemotes(apps, 'fly') }).decision).toBe('ask');
     });
 
     it('supports glob matching', () => {
-      expect(evalWith('fly ssh console -a staging-web -C "ls"', { trustedFlyApps: toTargets(apps) }).decision).toBe('allow');
+      expect(evalWith('fly ssh console -a staging-web -C "ls"', { trustedRemotes: toRemotes(apps, 'fly') }).decision).toBe('allow');
     });
 
     it('evaluates shell -c commands recursively', () => {
-      expect(evalWith('fly ssh console -a my-app -C "bash -c \\"ls | grep foo\\""', { trustedFlyApps: toTargets(apps) }).decision).toBe('allow');
+      expect(evalWith('fly ssh console -a my-app -C "bash -c \\"ls | grep foo\\""', { trustedRemotes: toRemotes(apps, 'fly') }).decision).toBe('allow');
     });
 
     it('flyctl alias works same as fly', () => {
-      expect(evalWith('flyctl ssh console -a my-app -C "ls"', { trustedFlyApps: toTargets(apps) }).decision).toBe('allow');
+      expect(evalWith('flyctl ssh console -a my-app -C "ls"', { trustedRemotes: toRemotes(apps, 'fly') }).decision).toBe('allow');
     });
 
     it('allowAll on trusted app allows everything', () => {
       expect(evalWith('fly ssh console -a my-app -C "sudo rm -rf /"', {
-        trustedFlyApps: [{ name: 'my-app', allowAll: true }],
+        trustedRemotes: [{ name: 'my-app', allowAll: true, context: 'fly' }],
       }).decision).toBe('allow');
     });
 
     it('per-app overrides work', () => {
       expect(evalWith('fly ssh console -a my-app -C "sudo apt install vim"', {
-        trustedFlyApps: [{ name: 'my-app', overrides: { alwaysAllow: ['sudo', 'apt'], alwaysDeny: [], rules: [] } }],
+        trustedRemotes: [{ name: 'my-app', overrides: { alwaysAllow: ['sudo', 'apt'], alwaysDeny: [], rules: [] }, context: 'fly' }],
       }).decision).toBe('allow');
     });
 
     it('non-ssh fly commands fall through to regular rules', () => {
-      const result = evalWith('fly status', { trustedFlyApps: toTargets(apps) });
+      const result = evalWith('fly status', { trustedRemotes: toRemotes(apps, 'fly') });
       expect(result.decision).toBe('allow');
     });
 
     it('fly deploy still asks', () => {
-      const result = evalWith('fly deploy', { trustedFlyApps: toTargets(apps) });
+      const result = evalWith('fly deploy', { trustedRemotes: toRemotes(apps, 'fly') });
       expect(result.decision).toBe('ask');
     });
 
     it('allows -- syntax for remote command', () => {
-      expect(evalWith('fly ssh console -a my-app -- ls -la', { trustedFlyApps: toTargets(apps) }).decision).toBe('allow');
+      expect(evalWith('fly ssh console -a my-app -- ls -la', { trustedRemotes: toRemotes(apps, 'fly') }).decision).toBe('allow');
     });
 
     it('allows bare bash on trusted app (interactive shell)', () => {
-      expect(evalWith('fly ssh console -a my-app -C "bash"', { trustedFlyApps: toTargets(apps) }).decision).toBe('allow');
+      expect(evalWith('fly ssh console -a my-app -C "bash"', { trustedRemotes: toRemotes(apps, 'fly') }).decision).toBe('allow');
     });
   });
 });

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -2,10 +2,14 @@ import { describe, it, expect } from 'vitest';
 import { parseCommand } from '../parser';
 import { evaluate } from '../evaluator';
 import { DEFAULT_CONFIG } from '../defaults';
-import type { WardenConfig, TrustedTarget } from '../types';
+import type { WardenConfig, TrustedTarget, TrustedRemote, RemoteContext } from '../types';
 
 function toTargets(items: (string | TrustedTarget)[]): TrustedTarget[] {
   return items.map(i => typeof i === 'string' ? { name: i } : i);
+}
+
+function toRemotes(items: (string | TrustedTarget)[], context: RemoteContext): TrustedRemote[] {
+  return toTargets(items).map(t => ({ ...t, context }));
 }
 
 /** Simulate the full pipeline: parse → evaluate with default config */
@@ -20,7 +24,7 @@ function wardenWith(command: string, overrides: Partial<WardenConfig>) {
 }
 
 function wardenWithSSH(command: string, trustedHosts: (string | TrustedTarget)[]) {
-  return wardenWith(command, { trustedSSHHosts: toTargets(trustedHosts) });
+  return wardenWith(command, { trustedRemotes: toRemotes(trustedHosts, 'ssh') });
 }
 
 describe('integration: realistic commands', () => {
@@ -340,23 +344,23 @@ describe('integration: realistic commands', () => {
     const containers = ['my-app', 'dev-*'];
 
     it('docker exec my-app cat /etc/hosts → allow', () => {
-      expect(wardenWith('docker exec my-app cat /etc/hosts', { trustedDockerContainers: toTargets(containers) }).decision).toBe('allow');
+      expect(wardenWith('docker exec my-app cat /etc/hosts', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('allow');
     });
 
     it('docker exec -it my-app → allow (interactive)', () => {
-      expect(wardenWith('docker exec -it my-app', { trustedDockerContainers: toTargets(containers) }).decision).toBe('allow');
+      expect(wardenWith('docker exec -it my-app', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('allow');
     });
 
     it('docker exec my-app sudo rm -rf / → deny', () => {
-      expect(wardenWith('docker exec my-app sudo rm -rf /', { trustedDockerContainers: toTargets(containers) }).decision).toBe('deny');
+      expect(wardenWith('docker exec my-app sudo rm -rf /', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('deny');
     });
 
     it('docker exec unknown-app ls → ask', () => {
-      expect(wardenWith('docker exec unknown-app ls', { trustedDockerContainers: toTargets(containers) }).decision).toBe('ask');
+      expect(wardenWith('docker exec unknown-app ls', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('ask');
     });
 
     it('docker exec dev-web npm start → allow (glob)', () => {
-      expect(wardenWith('docker exec dev-web npm start', { trustedDockerContainers: toTargets(containers) }).decision).toBe('allow');
+      expect(wardenWith('docker exec dev-web npm start', { trustedRemotes: toRemotes(containers, 'docker') }).decision).toBe('allow');
     });
   });
 
@@ -364,23 +368,23 @@ describe('integration: realistic commands', () => {
     const contexts = ['minikube', 'dev-*'];
 
     it('kubectl exec --context minikube pod -- cat /tmp/log → allow', () => {
-      expect(wardenWith('kubectl exec --context minikube pod -- cat /tmp/log', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('allow');
+      expect(wardenWith('kubectl exec --context minikube pod -- cat /tmp/log', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('allow');
     });
 
     it('kubectl exec --context minikube -it pod → allow (interactive)', () => {
-      expect(wardenWith('kubectl exec --context minikube -it pod', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('allow');
+      expect(wardenWith('kubectl exec --context minikube -it pod', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('allow');
     });
 
     it('kubectl exec --context minikube pod -- sudo rm -rf / → deny', () => {
-      expect(wardenWith('kubectl exec --context minikube pod -- sudo rm -rf /', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('deny');
+      expect(wardenWith('kubectl exec --context minikube pod -- sudo rm -rf /', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('deny');
     });
 
     it('kubectl exec --context production pod -- ls → ask (untrusted)', () => {
-      expect(wardenWith('kubectl exec --context production pod -- ls', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('ask');
+      expect(wardenWith('kubectl exec --context production pod -- ls', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('ask');
     });
 
     it('kubectl exec --context=dev-east pod -- ls → allow (=syntax, glob)', () => {
-      expect(wardenWith('kubectl exec --context=dev-east pod -- ls', { trustedKubectlContexts: toTargets(contexts) }).decision).toBe('allow');
+      expect(wardenWith('kubectl exec --context=dev-east pod -- ls', { trustedRemotes: toRemotes(contexts, 'kubectl') }).decision).toBe('allow');
     });
   });
 
@@ -422,27 +426,27 @@ describe('integration: realistic commands', () => {
     const sprites = ['my-sprite', 'dev-*'];
 
     it('sprite exec -s my-sprite ls -la → allow', () => {
-      expect(wardenWith('sprite exec -s my-sprite ls -la', { trustedSprites: toTargets(sprites) }).decision).toBe('allow');
+      expect(wardenWith('sprite exec -s my-sprite ls -la', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('allow');
     });
 
     it('sprite -o myorg -s my-sprite exec npm start → allow', () => {
-      expect(wardenWith('sprite -o myorg -s my-sprite exec npm start', { trustedSprites: toTargets(sprites) }).decision).toBe('allow');
+      expect(wardenWith('sprite -o myorg -s my-sprite exec npm start', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('allow');
     });
 
     it('sprite exec -s my-sprite sudo rm -rf / → deny', () => {
-      expect(wardenWith('sprite exec -s my-sprite sudo rm -rf /', { trustedSprites: toTargets(sprites) }).decision).toBe('deny');
+      expect(wardenWith('sprite exec -s my-sprite sudo rm -rf /', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('deny');
     });
 
     it('sprite exec -s unknown ls → ask (untrusted)', () => {
-      expect(wardenWith('sprite exec -s unknown ls', { trustedSprites: toTargets(sprites) }).decision).toBe('ask');
+      expect(wardenWith('sprite exec -s unknown ls', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('ask');
     });
 
     it('sprite console -s my-sprite → allow (interactive)', () => {
-      expect(wardenWith('sprite console -s my-sprite', { trustedSprites: toTargets(sprites) }).decision).toBe('allow');
+      expect(wardenWith('sprite console -s my-sprite', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('allow');
     });
 
     it('sprite exec -s dev-web cat /etc/hosts → allow (glob)', () => {
-      expect(wardenWith('sprite exec -s dev-web cat /etc/hosts', { trustedSprites: toTargets(sprites) }).decision).toBe('allow');
+      expect(wardenWith('sprite exec -s dev-web cat /etc/hosts', { trustedRemotes: toRemotes(sprites, 'sprite') }).decision).toBe('allow');
     });
   });
 

--- a/src/__tests__/targets.test.ts
+++ b/src/__tests__/targets.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect } from 'vitest';
+import { evaluate } from '../evaluator';
+import { parseCommand } from '../parser';
+import { DEFAULT_CONFIG } from '../defaults';
+import type { WardenConfig, PathPolicy, DatabasePolicy, EndpointPolicy } from '../types';
+
+function evalWith(cmd: string, overrides: Partial<WardenConfig>, cwd: string = '/home/user/project') {
+  const config: WardenConfig = { ...structuredClone(DEFAULT_CONFIG), ...overrides };
+  return evaluate(parseCommand(cmd), config, cwd);
+}
+
+// Helpers to build targetPolicies from shorthand
+function pathPolicies(paths: Omit<PathPolicy, 'type'>[]): { targetPolicies: PathPolicy[] } {
+  return { targetPolicies: paths.map(p => ({ ...p, type: 'path' as const })) };
+}
+
+function dbPolicies(dbs: Omit<DatabasePolicy, 'type'>[]): { targetPolicies: DatabasePolicy[] } {
+  return { targetPolicies: dbs.map(d => ({ ...d, type: 'database' as const })) };
+}
+
+function endpointPolicies(eps: Omit<EndpointPolicy, 'type'>[]): { targetPolicies: EndpointPolicy[] } {
+  return { targetPolicies: eps.map(e => ({ ...e, type: 'endpoint' as const })) };
+}
+
+describe('targetPolicies — path', () => {
+  it('allows rm -rf /tmp/build when /tmp is trusted recursive', () => {
+    const result = evalWith('rm -rf /tmp/build', pathPolicies([{ path: '/tmp', recursive: true, decision: 'allow' }]));
+    expect(result.decision).toBe('allow');
+    expect(result.details[0]?.matchedRule).toBe('trustedPaths');
+  });
+
+  it('does NOT allow rm -rf /tmp/../../etc (path traversal)', () => {
+    const result = evalWith('rm -rf /tmp/../../etc', pathPolicies([{ path: '/tmp', recursive: true, decision: 'allow' }]));
+    expect(result.decision).not.toBe('allow');
+  });
+
+  it('allows rm file.txt when {{cwd}} matches trusted path', () => {
+    const result = evalWith('rm file.txt', pathPolicies([{ path: '{{cwd}}', recursive: true, decision: 'allow' }]), '/home/user/project');
+    expect(result.decision).toBe('allow');
+  });
+
+  it('denies chmod 777 /etc/passwd when /etc has deny target', () => {
+    const result = evalWith('chmod 777 /etc/passwd', pathPolicies([{ path: '/etc', recursive: true, decision: 'deny' }]));
+    expect(result.decision).toBe('deny');
+    expect(result.details[0]?.matchedRule).toBe('trustedPaths');
+  });
+
+  it('filters by command list: cp allowed but curl not affected', () => {
+    const policies = pathPolicies([{ path: '/tmp', recursive: true, decision: 'allow', commands: ['cp', 'rm'] }]);
+    const cpResult = evalWith('cp /tmp/file /dest', policies);
+    expect(cpResult.decision).toBe('allow');
+
+    // curl /tmp/file — curl is not in commands list, so targetPolicies doesn't apply
+    const curlResult = evalWith('curl /tmp/file', policies);
+    expect(curlResult.details[0]?.matchedRule).not.toBe('trustedPaths');
+  });
+
+  it('deny takes precedence over allow with multiple targets', () => {
+    const result = evalWith('rm /shared/file.txt', {
+      targetPolicies: [
+        { type: 'path', path: '/shared', recursive: true, decision: 'allow' },
+        { type: 'path', path: '/shared', recursive: true, decision: 'deny' },
+      ],
+    });
+    expect(result.decision).toBe('deny');
+  });
+
+  it('non-recursive path matches exact only', () => {
+    const result = evalWith('rm /tmp/build/file.txt', pathPolicies([{ path: '/tmp/build', recursive: false, decision: 'allow' }]));
+    // /tmp/build/file.txt is NOT /tmp/build exactly
+    expect(result.details[0]?.matchedRule).not.toBe('trustedPaths');
+  });
+
+  it('non-recursive path matches exact file', () => {
+    const result = evalWith('rm /tmp/build', pathPolicies([{ path: '/tmp/build', recursive: false, decision: 'allow' }]));
+    expect(result.decision).toBe('allow');
+    expect(result.details[0]?.matchedRule).toBe('trustedPaths');
+  });
+
+  it('allowAll bypasses command filter and PATH_COMMANDS gate', () => {
+    // cat is in alwaysAllow so use a command that goes through rules
+    // Use a custom config without alwaysAllow to test allowAll properly
+    const config: WardenConfig = {
+      ...structuredClone(DEFAULT_CONFIG),
+      layers: [{ alwaysAllow: [], alwaysDeny: [], rules: [] }],
+      targetPolicies: [{ type: 'path', path: '/tmp', recursive: true, decision: 'deny', allowAll: true }],
+    };
+    const result = evaluate(parseCommand('somecommand /tmp/file'), config, '/home/user/project');
+    // allowAll overrides decision to 'allow'
+    expect(result.decision).toBe('allow');
+    expect(result.details[0]?.matchedRule).toBe('trustedPaths');
+  });
+});
+
+describe('targetPolicies — database', () => {
+  it('allows psql -h localhost -d testdb when localhost/testdb trusted', () => {
+    const result = evalWith('psql -h localhost -d testdb', dbPolicies([{ host: 'localhost', database: 'testdb', decision: 'allow' }]));
+    expect(result.decision).toBe('allow');
+    expect(result.details[0]?.matchedRule).toBe('trustedDatabases');
+  });
+
+  it('does not match psql -h prod.example.com -d main (not trusted)', () => {
+    const result = evalWith('psql -h prod.example.com -d main', dbPolicies([{ host: 'localhost', decision: 'allow' }]));
+    expect(result.details[0]?.matchedRule).not.toBe('trustedDatabases');
+  });
+
+  it('allows mysql --host=localhost --database=testdb', () => {
+    const result = evalWith('mysql --host=localhost --database=testdb', dbPolicies([{ host: 'localhost', database: 'testdb', decision: 'allow' }]));
+    expect(result.decision).toBe('allow');
+    expect(result.details[0]?.matchedRule).toBe('trustedDatabases');
+  });
+
+  it('allows psql postgresql://localhost/testdb', () => {
+    const result = evalWith('psql postgresql://localhost/testdb', dbPolicies([{ host: 'localhost', database: 'testdb', decision: 'allow' }]));
+    expect(result.decision).toBe('allow');
+    expect(result.details[0]?.matchedRule).toBe('trustedDatabases');
+  });
+
+  it('supports glob pattern for host', () => {
+    const result = evalWith('psql -h dev-db-01.internal -d myapp', dbPolicies([{ host: 'dev-*.internal', decision: 'allow' }]));
+    expect(result.decision).toBe('allow');
+  });
+
+  it('supports glob pattern for database', () => {
+    const result = evalWith('psql -h localhost -d test_myapp', dbPolicies([{ host: 'localhost', database: 'test_*', decision: 'allow' }]));
+    expect(result.decision).toBe('allow');
+  });
+
+  it('filters by port when specified', () => {
+    const result = evalWith('psql -h localhost -p 5433 -d testdb', dbPolicies([{ host: 'localhost', port: 5432, database: 'testdb', decision: 'allow' }]));
+    // Port mismatch — trustedDatabases should not match
+    expect(result.details[0]?.matchedRule).not.toBe('trustedDatabases');
+  });
+
+  it('does not match when target specifies database but command does not', () => {
+    const result = evalWith('psql -h localhost', dbPolicies([{ host: 'localhost', database: 'testdb', decision: 'allow' }]));
+    // target requires database=testdb but command has no -d flag → should NOT match
+    expect(result.details[0]?.matchedRule).not.toBe('trustedDatabases');
+  });
+
+  it('allows redis-cli -h localhost', () => {
+    const result = evalWith('redis-cli -h localhost', dbPolicies([{ host: 'localhost', decision: 'allow' }]));
+    expect(result.decision).toBe('allow');
+  });
+
+  it('allowAll allows any DB command to matching host', () => {
+    const result = evalWith('psql -h localhost -d mydb', {
+      targetPolicies: [{ type: 'database', host: 'localhost', decision: 'deny', allowAll: true }],
+    });
+    expect(result.decision).toBe('allow');
+    expect(result.details[0]?.matchedRule).toBe('trustedDatabases');
+  });
+});
+
+describe('targetPolicies — endpoint', () => {
+  it('allows curl http://localhost:3000/api when localhost:* trusted', () => {
+    const result = evalWith('curl http://localhost:3000/api', endpointPolicies([{ pattern: 'http://localhost:*', decision: 'allow' }]));
+    expect(result.decision).toBe('allow');
+    expect(result.details[0]?.matchedRule).toBe('trustedEndpoints');
+  });
+
+  it('does not match curl https://api.prod.example.com/delete (not trusted)', () => {
+    const result = evalWith('curl https://api.prod.example.com/delete', endpointPolicies([{ pattern: 'http://localhost:*', decision: 'allow' }]));
+    expect(result.details[0]?.matchedRule).not.toBe('trustedEndpoints');
+  });
+
+  it('allows wget http://localhost:8080/file', () => {
+    const result = evalWith('wget http://localhost:8080/file', endpointPolicies([{ pattern: 'http://localhost:*', decision: 'allow' }]));
+    expect(result.decision).toBe('allow');
+  });
+
+  it('handles curl --url flag', () => {
+    const result = evalWith('curl --url http://localhost:3000/api -X POST', endpointPolicies([{ pattern: 'http://localhost:*', decision: 'allow' }]));
+    expect(result.decision).toBe('allow');
+  });
+
+  it('filters by command list', () => {
+    const policies = endpointPolicies([{ pattern: 'http://localhost:*', decision: 'allow', commands: ['curl'] }]);
+    const curlResult = evalWith('curl http://localhost:3000/api', policies);
+    expect(curlResult.decision).toBe('allow');
+
+    const wgetResult = evalWith('wget http://localhost:3000/api', policies);
+    expect(wgetResult.details[0]?.matchedRule).not.toBe('trustedEndpoints');
+  });
+
+  it('supports https patterns', () => {
+    const result = evalWith('curl https://api.dev.example.com/users', endpointPolicies([{ pattern: 'https://api.dev.example.com/*', decision: 'allow' }]));
+    expect(result.decision).toBe('allow');
+  });
+
+  it('allowAll allows any HTTP command to matching endpoint', () => {
+    const result = evalWith('curl http://localhost:3000/api', {
+      targetPolicies: [{ type: 'endpoint', pattern: 'http://localhost:*', decision: 'deny', allowAll: true }],
+    });
+    expect(result.decision).toBe('allow');
+    expect(result.details[0]?.matchedRule).toBe('trustedEndpoints');
+  });
+});
+
+describe('integration with alwaysDeny', () => {
+  it('alwaysDeny still blocks even with trusted path (sudo rm /tmp/file)', () => {
+    const result = evalWith('sudo rm /tmp/file', pathPolicies([{ path: '/tmp', recursive: true, decision: 'allow' }]));
+    expect(result.decision).toBe('deny');
+  });
+
+  it('alwaysDeny still blocks even with allowAll path', () => {
+    const result = evalWith('sudo rm /tmp/file', {
+      targetPolicies: [{ type: 'path', path: '/tmp', recursive: true, decision: 'allow', allowAll: true }],
+    });
+    expect(result.decision).toBe('deny');
+  });
+});
+
+describe('target policies override command-specific rules', () => {
+  it('rm -rf /tmp/build → allow despite rm -rf usually being ask', () => {
+    // rm with -rf would normally trigger an ask pattern in default rules
+    const result = evalWith('rm -rf /tmp/build', pathPolicies([{ path: '/tmp', recursive: true, decision: 'allow' }]));
+    expect(result.decision).toBe('allow');
+    expect(result.details[0]?.matchedRule).toBe('trustedPaths');
+  });
+});

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -92,11 +92,8 @@ export const DEFAULT_CONFIG: WardenConfig = {
   askOnSubshell: true,
   notifyOnAsk: true,
   notifyOnDeny: true,
-  trustedSSHHosts: [],
-  trustedDockerContainers: [],
-  trustedKubectlContexts: [],
-  trustedSprites: [],
-  trustedFlyApps: [],
+  trustedRemotes: [],
+  targetPolicies: [],
 
   layers: [{
     alwaysAllow: [

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -4,6 +4,8 @@ import type {
   CommandEvalDetail, ParsedCommand, CommandRule, TrustedTarget,
 } from './types';
 import { parseCommand } from './parser';
+import { evaluateTargetPolicies } from './targets';
+import { globToRegex } from './glob';
 
 /** Safely test a regex pattern, returning false on invalid patterns. */
 function safeRegexTest(pattern: string, input: string): boolean {
@@ -32,7 +34,14 @@ function commandMatchesName(cmd: ParsedCommand, name: string): boolean {
 
 const MAX_RECURSION_DEPTH = 10;
 
-export function evaluate(parsed: ParseResult, config: WardenConfig, depth: number = 0): EvalResult {
+export function evaluate(parsed: ParseResult, config: WardenConfig, cwd?: string, depth?: number): EvalResult;
+/** @deprecated Use the 4-arg form with cwd */
+export function evaluate(parsed: ParseResult, config: WardenConfig, depth?: number): EvalResult;
+export function evaluate(parsed: ParseResult, config: WardenConfig, cwdOrDepth?: string | number, maybeDepth?: number): EvalResult {
+  // Disambiguate overloads: string → cwd, number → depth
+  const cwd = typeof cwdOrDepth === 'string' ? cwdOrDepth : undefined;
+  const depth = typeof cwdOrDepth === 'number' ? cwdOrDepth : (maybeDepth ?? 0);
+
   if (depth > MAX_RECURSION_DEPTH) {
     return { decision: 'ask', reason: 'Maximum recursion depth exceeded', details: [] };
   }
@@ -49,7 +58,7 @@ export function evaluate(parsed: ParseResult, config: WardenConfig, depth: numbe
   if (parsed.hasSubshell && parsed.subshellCommands.length > 0) {
     for (const subCmd of parsed.subshellCommands) {
       const subParsed = parseCommand(subCmd);
-      const subResult = evaluate(subParsed, config, depth + 1);
+      const subResult = evaluate(subParsed, config, cwd, depth + 1);
       if (subResult.decision === 'deny') {
         return { decision: 'deny', reason: `Subshell command: ${subResult.reason}`, details: subResult.details };
       }
@@ -64,7 +73,7 @@ export function evaluate(parsed: ParseResult, config: WardenConfig, depth: numbe
 
   const details: CommandEvalDetail[] = [];
   for (const cmd of parsed.commands) {
-    details.push(evaluateCommand(cmd, config, depth));
+    details.push(evaluateCommand(cmd, config, cwd, depth));
   }
 
   // Combine: deny > ask > allow
@@ -91,7 +100,7 @@ export function evaluate(parsed: ParseResult, config: WardenConfig, depth: numbe
   return { decision: 'allow', reason: 'All commands are safe', details };
 }
 
-function evaluateCommand(cmd: ParsedCommand, config: WardenConfig, depth: number = 0): CommandEvalDetail {
+function evaluateCommand(cmd: ParsedCommand, config: WardenConfig, cwd?: string, depth: number = 0): CommandEvalDetail {
   const { command, args } = cmd;
 
   // 1. Scoped alwaysDeny → alwaysAllow per layer (workspace > user > default)
@@ -104,32 +113,55 @@ function evaluateCommand(cmd: ParsedCommand, config: WardenConfig, depth: number
     }
   }
 
-  // 2. Remote target whitelisting with recursive command evaluation
-  if ((command === 'ssh' || command === 'scp' || command === 'rsync') && config.trustedSSHHosts?.length) {
-    const sshResult = evaluateSSHCommand(cmd, config, depth);
-    if (sshResult) return sshResult;
+  // 2. Target-based policy overrides (paths, databases, endpoints)
+  if (cwd) {
+    const targetResult = evaluateTargetPolicies(cmd, cwd, config);
+    if (targetResult) return targetResult;
   }
-  if (command === 'docker' && config.trustedDockerContainers?.length) {
-    const dockerResult = evaluateDockerExec(cmd, config, depth);
-    if (dockerResult) return dockerResult;
+
+  // 3. Remote target whitelisting with recursive command evaluation
+  const remotes = config.trustedRemotes || [];
+
+  if (command === 'ssh' || command === 'scp' || command === 'rsync') {
+    const sshTargets = remotes.filter(r => r.context === 'ssh');
+    if (sshTargets.length) {
+      const sshResult = evaluateSSHCommand(cmd, config, sshTargets, depth);
+      if (sshResult) return sshResult;
+    }
   }
-  if (command === 'kubectl' && config.trustedKubectlContexts?.length) {
-    const kubectlResult = evaluateKubectlExec(cmd, config, depth);
-    if (kubectlResult) return kubectlResult;
+  if (command === 'docker') {
+    const dockerTargets = remotes.filter(r => r.context === 'docker');
+    if (dockerTargets.length) {
+      const dockerResult = evaluateDockerExec(cmd, config, dockerTargets, depth);
+      if (dockerResult) return dockerResult;
+    }
   }
-  if (command === 'sprite' && config.trustedSprites?.length) {
-    const spriteResult = evaluateSpriteExec(cmd, config, depth);
-    if (spriteResult) return spriteResult;
+  if (command === 'kubectl') {
+    const kubectlTargets = remotes.filter(r => r.context === 'kubectl');
+    if (kubectlTargets.length) {
+      const kubectlResult = evaluateKubectlExec(cmd, config, kubectlTargets, depth);
+      if (kubectlResult) return kubectlResult;
+    }
   }
-  if ((command === 'fly' || command === 'flyctl') && config.trustedFlyApps?.length) {
-    const flyResult = evaluateFlyCommand(cmd, config, depth);
-    if (flyResult) return flyResult;
+  if (command === 'sprite') {
+    const spriteTargets = remotes.filter(r => r.context === 'sprite');
+    if (spriteTargets.length) {
+      const spriteResult = evaluateSpriteExec(cmd, config, spriteTargets, depth);
+      if (spriteResult) return spriteResult;
+    }
+  }
+  if (command === 'fly' || command === 'flyctl') {
+    const flyTargets = remotes.filter(r => r.context === 'fly');
+    if (flyTargets.length) {
+      const flyResult = evaluateFlyCommand(cmd, config, flyTargets, depth);
+      if (flyResult) return flyResult;
+    }
   }
   if (command === 'xargs') {
-    return evaluateXargsCommand(cmd, config, depth);
+    return evaluateXargsCommand(cmd, config, cwd, depth);
   }
   if (command === 'find') {
-    return evaluateFindCommand(cmd, config, depth);
+    return evaluateFindCommand(cmd, config, cwd, depth);
   }
 
   // 3. Scoped command rules — collect and merge across layers
@@ -325,7 +357,7 @@ function parseXargsSubcommand(args: string[]): { subcommand: ParsedCommand | nul
   };
 }
 
-function evaluateXargsCommand(cmd: ParsedCommand, config: WardenConfig, depth: number = 0): CommandEvalDetail {
+function evaluateXargsCommand(cmd: ParsedCommand, config: WardenConfig, cwd?: string, depth: number = 0): CommandEvalDetail {
   const { command, args } = cmd;
   const { subcommand, unresolved } = parseXargsSubcommand(args);
 
@@ -357,7 +389,7 @@ function evaluateXargsCommand(cmd: ParsedCommand, config: WardenConfig, depth: n
     parsed = { commands: [subcommand], hasSubshell: false, subshellCommands: [], parseError: false };
   }
 
-  const result = evaluate(parsed, config, depth + 1);
+  const result = evaluate(parsed, config, cwd, depth + 1);
 
   return {
     command,
@@ -402,7 +434,7 @@ function parseFindExecCommands(args: string[]): ParsedCommand[] {
   return commands;
 }
 
-function evaluateFindCommand(cmd: ParsedCommand, config: WardenConfig, depth: number = 0): CommandEvalDetail {
+function evaluateFindCommand(cmd: ParsedCommand, config: WardenConfig, cwd?: string, depth: number = 0): CommandEvalDetail {
   const { command, args } = cmd;
 
   // -delete, -ok, -okdir are inherently dangerous
@@ -427,7 +459,7 @@ function evaluateFindCommand(cmd: ParsedCommand, config: WardenConfig, depth: nu
       subshellCommands: [],
       parseError: false,
     };
-    const result = evaluate(parsed, config, depth + 1);
+    const result = evaluate(parsed, config, cwd, depth + 1);
     if (result.decision === 'deny') {
       return { command, args, decision: 'deny', reason: `find -exec: ${result.reason}`, matchedRule: 'find:exec' };
     }
@@ -444,53 +476,6 @@ const SSH_FLAGS_WITH_VALUE = new Set([
   '-b', '-c', '-D', '-E', '-e', '-F', '-I', '-i', '-J', '-L',
   '-l', '-m', '-O', '-o', '-p', '-Q', '-R', '-S', '-W', '-w',
 ]);
-
-/** Convert a glob pattern to a RegExp. Supports *, ?, [...], and {a,b,c}. */
-function globToRegex(pattern: string): RegExp {
-  let regex = '';
-  let i = 0;
-  while (i < pattern.length) {
-    const ch = pattern[i];
-    if (ch === '*') {
-      regex += '.*';
-    } else if (ch === '?') {
-      regex += '.';
-    } else if (ch === '[') {
-      // Pass through character class until closing ]
-      i++;
-      // Handle negation [!...] → [^...]
-      if (i < pattern.length && pattern[i] === '!') {
-        regex += '[^';
-        i++;
-      } else {
-        regex += '[';
-      }
-      while (i < pattern.length && pattern[i] !== ']') {
-        regex += pattern[i];
-        i++;
-      }
-      if (i < pattern.length) {
-        regex += ']';
-      }
-    } else if (ch === '{') {
-      // Brace expansion {a,b,c} → (a|b|c)
-      const end = pattern.indexOf('}', i);
-      if (end !== -1) {
-        const alternatives = pattern.slice(i + 1, end).split(',').map(s => s.replace(/[.+^$|\\()]/g, '\\$&'));
-        regex += `(${alternatives.join('|')})`;
-        i = end;
-      } else {
-        regex += '\\{';
-      }
-    } else if ('.+^$|\\()'.includes(ch)) {
-      regex += '\\' + ch;
-    } else {
-      regex += ch;
-    }
-    i++;
-  }
-  return new RegExp(`^${regex}$`);
-}
 
 function matchesPattern(value: string, targets: TrustedTarget[]): boolean {
   return targets.some(t => globToRegex(t.name).test(value));
@@ -549,14 +534,13 @@ function extractHostFromRemotePath(args: string[]): string | null {
   return null;
 }
 
-function evaluateSSHCommand(cmd: ParsedCommand, config: WardenConfig, depth: number = 0): CommandEvalDetail | null {
+function evaluateSSHCommand(cmd: ParsedCommand, config: WardenConfig, targets: TrustedTarget[], depth: number = 0): CommandEvalDetail | null {
   const { command, args } = cmd;
-  const trustedHosts = config.trustedSSHHosts || [];
 
   if (command === 'scp' || command === 'rsync') {
     const host = extractHostFromRemotePath(args);
     if (!host) return null;
-    const target = findMatchingTarget(host, trustedHosts);
+    const target = findMatchingTarget(host, targets);
     if (!target) return null;
     if (target.allowAll || !target.overrides) {
       return {
@@ -585,7 +569,7 @@ function evaluateSSHCommand(cmd: ParsedCommand, config: WardenConfig, depth: num
   // ssh
   const { host, remoteCommand } = parseSSHArgs(args);
   if (!host) return null;
-  const target = findMatchingTarget(host, trustedHosts);
+  const target = findMatchingTarget(host, targets);
   if (!target) return null;
 
   // Trusted host, no remote command
@@ -728,13 +712,13 @@ function parseDockerExecArgs(args: string[]): ExecParseResult {
   return { target, remoteArgs };
 }
 
-function evaluateDockerExec(cmd: ParsedCommand, config: WardenConfig, depth: number = 0): CommandEvalDetail | null {
+function evaluateDockerExec(cmd: ParsedCommand, config: WardenConfig, targets: TrustedTarget[], depth: number = 0): CommandEvalDetail | null {
   const { command, args } = cmd;
   if (args[0] !== 'exec') return null;
 
   const { target: containerName, remoteArgs } = parseDockerExecArgs(args.slice(1));
   if (!containerName) return null;
-  const matched = findMatchingTarget(containerName, config.trustedDockerContainers || []);
+  const matched = findMatchingTarget(containerName, targets);
   if (!matched) return null;
 
   const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);
@@ -803,13 +787,13 @@ function parseKubectlExecArgs(args: string[]): { context: string | null; pod: st
   return { context, pod, remoteArgs };
 }
 
-function evaluateKubectlExec(cmd: ParsedCommand, config: WardenConfig, depth: number = 0): CommandEvalDetail | null {
+function evaluateKubectlExec(cmd: ParsedCommand, config: WardenConfig, targets: TrustedTarget[], depth: number = 0): CommandEvalDetail | null {
   const { command, args } = cmd;
   if (args[0] !== 'exec') return null;
 
   const { context, pod, remoteArgs } = parseKubectlExecArgs(args.slice(1));
   if (!context) return null;
-  const matched = findMatchingTarget(context, config.trustedKubectlContexts || []);
+  const matched = findMatchingTarget(context, targets);
   if (!matched) return null;
 
   const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);
@@ -886,11 +870,11 @@ function parseSpriteExecArgs(args: string[]): { spriteName: string | null; remot
   return { spriteName, remoteArgs };
 }
 
-function evaluateSpriteExec(cmd: ParsedCommand, config: WardenConfig, depth: number = 0): CommandEvalDetail | null {
+function evaluateSpriteExec(cmd: ParsedCommand, config: WardenConfig, targets: TrustedTarget[], depth: number = 0): CommandEvalDetail | null {
   const { command, args } = cmd;
   const { spriteName, remoteArgs } = parseSpriteExecArgs(args);
   if (!spriteName) return null;
-  const matched = findMatchingTarget(spriteName, config.trustedSprites || []);
+  const matched = findMatchingTarget(spriteName, targets);
   if (!matched) return null;
 
   const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);
@@ -990,7 +974,7 @@ function parseFlySSHArgs(args: string[]): FlySSHParseResult {
   return { app, remoteArgs, isSSH: isSSH && foundConsole };
 }
 
-function evaluateFlyCommand(cmd: ParsedCommand, config: WardenConfig, depth: number = 0): CommandEvalDetail | null {
+function evaluateFlyCommand(cmd: ParsedCommand, config: WardenConfig, targets: TrustedTarget[], depth: number = 0): CommandEvalDetail | null {
   const { command, args } = cmd;
   const { app, remoteArgs, isSSH } = parseFlySSHArgs(args);
 
@@ -998,7 +982,7 @@ function evaluateFlyCommand(cmd: ParsedCommand, config: WardenConfig, depth: num
   if (!isSSH) return null;
   if (!app) return null;
 
-  const matched = findMatchingTarget(app, config.trustedFlyApps || []);
+  const matched = findMatchingTarget(app, targets);
   if (!matched) return null;
 
   const result = evaluateRemoteCommand(remoteArgs, config, matched, depth);

--- a/src/glob.ts
+++ b/src/glob.ts
@@ -1,0 +1,41 @@
+/** Convert a glob pattern to a RegExp. Supports *, ?, [...], and {a,b,c}. */
+export function globToRegex(pattern: string): RegExp {
+  let regex = '';
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === '*') {
+      regex += '.*';
+    } else if (ch === '?') {
+      regex += '.';
+    } else if (ch === '[') {
+      i++;
+      if (i < pattern.length && pattern[i] === '!') {
+        regex += '[^';
+        i++;
+      } else {
+        regex += '[';
+      }
+      while (i < pattern.length && pattern[i] !== ']') {
+        regex += pattern[i];
+        i++;
+      }
+      if (i < pattern.length) regex += ']';
+    } else if (ch === '{') {
+      const end = pattern.indexOf('}', i);
+      if (end !== -1) {
+        const alternatives = pattern.slice(i + 1, end).split(',').map(s => s.replace(/[.+^$|\\()]/g, '\\$&'));
+        regex += `(${alternatives.join('|')})`;
+        i = end;
+      } else {
+        regex += '\\{';
+      }
+    } else if ('.+^$|\\()'.includes(ch)) {
+      regex += '\\' + ch;
+    } else {
+      regex += ch;
+    }
+    i++;
+  }
+  return new RegExp(`^${regex}$`);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ async function main() {
   const yoloState = getYoloState(input.session_id);
   if (yoloState) {
     const parsed = parseCommand(command);
-    const result = evaluate(parsed, config);
+    const result = evaluate(parsed, config, input.cwd);
 
     // In YOLO mode, only block alwaysDeny commands (unless bypassDeny is set)
     if (result.decision === 'deny' && !yoloState.bypassDeny) {

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -2,7 +2,10 @@ import { readFileSync, existsSync } from 'fs';
 import { parse as parseYaml } from 'yaml';
 import { homedir } from 'os';
 import { join } from 'path';
-import type { WardenConfig, ConfigLayer, CommandRule, TrustedTarget } from './types';
+import type {
+  WardenConfig, ConfigLayer, CommandRule, TrustedTarget,
+  TrustedRemote, RemoteContext, TargetPolicy, PathPolicy, DatabasePolicy, EndpointPolicy,
+} from './types';
 import { DEFAULT_CONFIG } from './defaults';
 
 const VALID_DECISIONS = new Set(['allow', 'deny', 'ask']);
@@ -166,22 +169,171 @@ export function parseTrustedList(raw: unknown[]): TrustedTarget[] {
   }).filter((t): t is TrustedTarget => t !== null);
 }
 
+const VALID_REMOTE_CONTEXTS = new Set<RemoteContext>(['ssh', 'docker', 'kubectl', 'sprite', 'fly']);
+
+function parseTrustedRemotes(raw: unknown[]): TrustedRemote[] {
+  const results: TrustedRemote[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const obj = entry as Record<string, unknown>;
+    const context = String(obj.context || '');
+    if (!VALID_REMOTE_CONTEXTS.has(context as RemoteContext)) {
+      process.stderr.write(`[warden] Warning: unknown remote context "${context}", skipping\n`);
+      continue;
+    }
+    const name = String(obj.name || '');
+    if (!name) continue;
+    const remote: TrustedRemote = { name, context: context as RemoteContext };
+    if (obj.allowAll === true) remote.allowAll = true;
+    if (obj.overrides && typeof obj.overrides === 'object') {
+      remote.overrides = extractLayer(obj.overrides as Record<string, unknown>);
+    }
+    results.push(remote);
+  }
+  return results;
+}
+
+function parseTargetPolicies(raw: unknown[]): TargetPolicy[] {
+  const results: TargetPolicy[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const obj = entry as Record<string, unknown>;
+    const type = String(obj.type || '');
+
+    const rawDecision = String(obj.decision || 'allow');
+    const decision: 'allow' | 'deny' | 'ask' = isValidDecision(rawDecision) ? rawDecision as 'allow' | 'deny' | 'ask' : 'allow';
+
+    const base = {
+      commands: Array.isArray(obj.commands) ? obj.commands.map(String) : undefined,
+      decision,
+      reason: obj.reason ? String(obj.reason) : undefined,
+      allowAll: obj.allowAll === true ? true : undefined,
+    };
+
+    switch (type) {
+      case 'path': {
+        const path = String(obj.path || '');
+        if (!path) continue;
+        const policy: PathPolicy = { ...base, type: 'path', path };
+        if (obj.recursive === false) policy.recursive = false;
+        results.push(policy);
+        break;
+      }
+      case 'database': {
+        const host = String(obj.host || '');
+        if (!host) continue;
+        const policy: DatabasePolicy = { ...base, type: 'database', host };
+        if (typeof obj.port === 'number') policy.port = obj.port;
+        if (obj.database) policy.database = String(obj.database);
+        results.push(policy);
+        break;
+      }
+      case 'endpoint': {
+        const pattern = String(obj.pattern || '');
+        if (!pattern) continue;
+        results.push({ ...base, type: 'endpoint', pattern });
+        break;
+      }
+      default:
+        process.stderr.write(`[warden] Warning: unknown target policy type "${type}", skipping\n`);
+    }
+  }
+  return results;
+}
+
+// Legacy parsers — convert old format to unified TargetPolicy types
+
+function parseLegacyPaths(raw: unknown[]): PathPolicy[] {
+  const results: PathPolicy[] = [];
+  for (const e of raw) {
+    if (!e || typeof e !== 'object') continue;
+    const obj = e as Record<string, unknown>;
+    const decision = String(obj.decision || 'allow');
+    if (!isValidDecision(decision)) continue;
+    const path = String(obj.path || '');
+    if (!path) continue;
+    const tp: PathPolicy = { type: 'path', path, decision: decision as PathPolicy['decision'] };
+    if (obj.recursive === false) tp.recursive = false;
+    if (Array.isArray(obj.commands)) tp.commands = obj.commands.map(String);
+    if (obj.reason) tp.reason = String(obj.reason);
+    results.push(tp);
+  }
+  return results;
+}
+
+function parseLegacyDatabases(raw: unknown[]): DatabasePolicy[] {
+  const results: DatabasePolicy[] = [];
+  for (const e of raw) {
+    if (!e || typeof e !== 'object') continue;
+    const obj = e as Record<string, unknown>;
+    const decision = String(obj.decision || 'allow');
+    if (!isValidDecision(decision)) continue;
+    const host = String(obj.host || '');
+    if (!host) continue;
+    const td: DatabasePolicy = { type: 'database', host, decision: decision as DatabasePolicy['decision'] };
+    if (typeof obj.port === 'number') td.port = obj.port;
+    if (obj.database) td.database = String(obj.database);
+    if (Array.isArray(obj.commands)) td.commands = obj.commands.map(String);
+    if (obj.reason) td.reason = String(obj.reason);
+    results.push(td);
+  }
+  return results;
+}
+
+function parseLegacyEndpoints(raw: unknown[]): EndpointPolicy[] {
+  const results: EndpointPolicy[] = [];
+  for (const e of raw) {
+    if (!e || typeof e !== 'object') continue;
+    const obj = e as Record<string, unknown>;
+    const decision = String(obj.decision || 'allow');
+    if (!isValidDecision(decision)) continue;
+    const pattern = String(obj.pattern || '');
+    if (!pattern) continue;
+    const te: EndpointPolicy = { type: 'endpoint', pattern, decision: decision as EndpointPolicy['decision'] };
+    if (Array.isArray(obj.commands)) te.commands = obj.commands.map(String);
+    if (obj.reason) te.reason = String(obj.reason);
+    results.push(te);
+  }
+  return results;
+}
+
+// Legacy remote context key → RemoteContext mapping
+const LEGACY_REMOTE_MAP: Record<string, RemoteContext> = {
+  trustedSSHHosts: 'ssh',
+  trustedDockerContainers: 'docker',
+  trustedKubectlContexts: 'kubectl',
+  trustedSprites: 'sprite',
+  trustedFlyApps: 'fly',
+};
+
 function mergeNonLayerFields(config: WardenConfig, raw: Record<string, unknown>): void {
-  if (Array.isArray(raw.trustedSSHHosts)) {
-    config.trustedSSHHosts = [...(config.trustedSSHHosts || []), ...parseTrustedList(raw.trustedSSHHosts)];
+  // Unified keys (processed first)
+  if (Array.isArray(raw.trustedRemotes)) {
+    config.trustedRemotes = [...(config.trustedRemotes || []), ...parseTrustedRemotes(raw.trustedRemotes)];
   }
-  if (Array.isArray(raw.trustedDockerContainers)) {
-    config.trustedDockerContainers = [...(config.trustedDockerContainers || []), ...parseTrustedList(raw.trustedDockerContainers)];
+  if (Array.isArray(raw.targetPolicies)) {
+    config.targetPolicies = [...(config.targetPolicies || []), ...parseTargetPolicies(raw.targetPolicies)];
   }
-  if (Array.isArray(raw.trustedKubectlContexts)) {
-    config.trustedKubectlContexts = [...(config.trustedKubectlContexts || []), ...parseTrustedList(raw.trustedKubectlContexts)];
+
+  // Legacy remote context aliases → append to trustedRemotes
+  for (const [key, context] of Object.entries(LEGACY_REMOTE_MAP)) {
+    if (Array.isArray(raw[key])) {
+      const remotes = parseTrustedList(raw[key] as unknown[]).map(t => ({ ...t, context }));
+      config.trustedRemotes = [...(config.trustedRemotes || []), ...remotes];
+    }
   }
-  if (Array.isArray(raw.trustedSprites)) {
-    config.trustedSprites = [...(config.trustedSprites || []), ...parseTrustedList(raw.trustedSprites)];
+
+  // Legacy data target aliases → append to targetPolicies
+  if (Array.isArray(raw.trustedPaths)) {
+    config.targetPolicies = [...(config.targetPolicies || []), ...parseLegacyPaths(raw.trustedPaths)];
   }
-  if (Array.isArray(raw.trustedFlyApps)) {
-    config.trustedFlyApps = [...(config.trustedFlyApps || []), ...parseTrustedList(raw.trustedFlyApps)];
+  if (Array.isArray(raw.trustedDatabases)) {
+    config.targetPolicies = [...(config.targetPolicies || []), ...parseLegacyDatabases(raw.trustedDatabases)];
   }
+  if (Array.isArray(raw.trustedEndpoints)) {
+    config.targetPolicies = [...(config.targetPolicies || []), ...parseLegacyEndpoints(raw.trustedEndpoints)];
+  }
+
   if (typeof raw.defaultDecision === 'string') {
     if (isValidDecision(raw.defaultDecision)) {
       config.defaultDecision = raw.defaultDecision;

--- a/src/targets.ts
+++ b/src/targets.ts
@@ -1,0 +1,319 @@
+import { resolve, normalize } from 'path';
+import type {
+  ParsedCommand, WardenConfig, CommandEvalDetail,
+  PathPolicy, DatabasePolicy, EndpointPolicy,
+} from './types';
+import { globToRegex } from './glob';
+
+// Commands known to operate on filesystem paths
+const PATH_COMMANDS = new Set([
+  'rm', 'chmod', 'chown', 'cp', 'mv', 'tee', 'mkdir', 'rmdir', 'touch', 'ln',
+]);
+
+export function evaluatePathTarget(
+  cmd: ParsedCommand,
+  cwd: string,
+  targets: PathPolicy[],
+): CommandEvalDetail | null {
+  if (targets.length === 0) return null;
+
+  // Extract positional args (skip flags)
+  const positionalArgs = cmd.args.filter(a => !a.startsWith('-'));
+  if (positionalArgs.length === 0) return null;
+
+  let bestMatch: CommandEvalDetail | null = null;
+
+  for (const target of targets) {
+    // allowAll: match any command, skip commands filter and PATH_COMMANDS gate
+    if (target.allowAll) {
+      // Still need path to match
+    } else {
+      // Filter by command list if specified
+      if (target.commands && target.commands.length > 0 && !target.commands.includes(cmd.command)) {
+        continue;
+      }
+
+      // Skip if command isn't a path-operating command (when no commands filter specified)
+      if (!target.commands && !PATH_COMMANDS.has(cmd.command)) {
+        continue;
+      }
+    }
+
+    const targetPath = normalize(target.path.replace(/\{\{cwd\}\}/g, cwd));
+    const recursive = target.recursive !== false; // default true
+
+    for (const arg of positionalArgs) {
+      const resolvedArg = normalize(resolve(cwd, arg));
+
+      const matches = recursive
+        ? resolvedArg === targetPath || resolvedArg.startsWith(targetPath + '/')
+        : resolvedArg === targetPath;
+
+      if (matches) {
+        const decision = target.allowAll ? 'allow' as const : target.decision;
+        const detail: CommandEvalDetail = {
+          command: cmd.command,
+          args: cmd.args,
+          decision,
+          reason: target.reason || `Path "${resolvedArg}" matches trusted path "${target.path}" (${decision})`,
+          matchedRule: 'trustedPaths',
+        };
+        // Deny takes precedence
+        if (decision === 'deny') return detail;
+        if (!bestMatch || bestMatch.decision !== 'deny') {
+          bestMatch = detail;
+        }
+      }
+    }
+  }
+
+  return bestMatch;
+}
+
+// DB command flag mappings
+const DB_HOST_FLAGS: Record<string, string[]> = {
+  psql: ['-h', '--host'],
+  mysql: ['-h', '--host'],
+  mariadb: ['-h', '--host'],
+  'redis-cli': ['-h'],
+  mongosh: ['--host'],
+};
+
+const DB_DATABASE_FLAGS: Record<string, string[]> = {
+  psql: ['-d', '--dbname'],
+  mysql: ['-D', '--database'],
+  mariadb: ['-D', '--database'],
+};
+
+const DB_PORT_FLAGS: Record<string, string[]> = {
+  psql: ['-p', '--port'],
+  mysql: ['-P', '--port'],
+  mariadb: ['-P', '--port'],
+  'redis-cli': ['-p'],
+  mongosh: ['--port'],
+};
+
+interface DBConnectionInfo {
+  host?: string;
+  port?: number;
+  database?: string;
+}
+
+function extractFlagValue(args: string[], flags: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    // --flag=value
+    for (const f of flags) {
+      if (arg.startsWith(f + '=')) {
+        return arg.slice(f.length + 1);
+      }
+    }
+    // --flag value
+    if (flags.includes(arg) && i + 1 < args.length) {
+      return args[i + 1];
+    }
+  }
+  return undefined;
+}
+
+function parseDBConnection(cmd: ParsedCommand): DBConnectionInfo {
+  const command = cmd.command;
+  const info: DBConnectionInfo = {};
+
+  // Check for URI format
+  for (const arg of cmd.args) {
+    if (arg.startsWith('postgresql://') || arg.startsWith('postgres://')) {
+      try {
+        const url = new URL(arg);
+        info.host = url.hostname;
+        if (url.port) info.port = parseInt(url.port, 10);
+        if (url.pathname.length > 1) info.database = url.pathname.slice(1);
+        return info;
+      } catch { /* not a valid URL, continue */ }
+    }
+    if (arg.startsWith('mongodb://') || arg.startsWith('mongodb+srv://')) {
+      try {
+        const url = new URL(arg);
+        info.host = url.hostname;
+        if (url.port) info.port = parseInt(url.port, 10);
+        if (url.pathname.length > 1) info.database = url.pathname.slice(1);
+        return info;
+      } catch { /* not a valid URL, continue */ }
+    }
+  }
+
+  // Flag-based parsing
+  const hostFlags = DB_HOST_FLAGS[command];
+  if (hostFlags) {
+    const h = extractFlagValue(cmd.args, hostFlags);
+    if (h) info.host = h;
+  }
+
+  const dbFlags = DB_DATABASE_FLAGS[command];
+  if (dbFlags) {
+    const d = extractFlagValue(cmd.args, dbFlags);
+    if (d) info.database = d;
+  }
+
+  const portFlags = DB_PORT_FLAGS[command];
+  if (portFlags) {
+    const p = extractFlagValue(cmd.args, portFlags);
+    if (p) info.port = parseInt(p, 10);
+  }
+
+  return info;
+}
+
+const DB_COMMANDS = new Set(Object.keys(DB_HOST_FLAGS));
+
+export function evaluateDatabaseTarget(
+  cmd: ParsedCommand,
+  targets: DatabasePolicy[],
+): CommandEvalDetail | null {
+  if (targets.length === 0) return null;
+
+  // allowAll targets can match any command that has DB connection info
+  const hasAllowAll = targets.some(t => t.allowAll);
+  if (!hasAllowAll && !DB_COMMANDS.has(cmd.command)) return null;
+
+  // For non-allowAll targets, still gate on DB_COMMANDS
+  const applicableTargets = targets.filter(t => t.allowAll || DB_COMMANDS.has(cmd.command));
+  if (applicableTargets.length === 0) return null;
+
+  const conn = parseDBConnection(cmd);
+  if (!conn.host) return null;
+
+  let bestMatch: CommandEvalDetail | null = null;
+
+  for (const target of applicableTargets) {
+    if (!target.allowAll && target.commands && target.commands.length > 0 && !target.commands.includes(cmd.command)) {
+      continue;
+    }
+
+    const hostMatch = globToRegex(target.host).test(conn.host);
+    if (!hostMatch) continue;
+
+    if (target.port !== undefined && conn.port !== undefined && target.port !== conn.port) {
+      continue;
+    }
+
+    if (target.database) {
+      // If target specifies a database, the command must also specify one and it must match
+      if (!conn.database || !globToRegex(target.database).test(conn.database)) continue;
+    }
+
+    const decision = target.allowAll ? 'allow' as const : target.decision;
+    const detail: CommandEvalDetail = {
+      command: cmd.command,
+      args: cmd.args,
+      decision,
+      reason: target.reason || `Database "${conn.host}${conn.database ? '/' + conn.database : ''}" matches trusted database (${decision})`,
+      matchedRule: 'trustedDatabases',
+    };
+
+    if (decision === 'deny') return detail;
+    if (!bestMatch) bestMatch = detail;
+  }
+
+  return bestMatch;
+}
+
+const ENDPOINT_COMMANDS = new Set(['curl', 'wget', 'http', 'httpie']);
+
+function extractURLs(cmd: ParsedCommand): string[] {
+  const urls: string[] = [];
+  const args = cmd.args;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    // curl --url flag
+    if ((arg === '--url') && i + 1 < args.length) {
+      urls.push(args[i + 1]);
+      i++;
+      continue;
+    }
+    // Positional URLs (starts with http:// or https://)
+    if (arg.startsWith('http://') || arg.startsWith('https://')) {
+      urls.push(arg);
+    }
+  }
+
+  return urls;
+}
+
+export function evaluateEndpointTarget(
+  cmd: ParsedCommand,
+  targets: EndpointPolicy[],
+): CommandEvalDetail | null {
+  if (targets.length === 0) return null;
+
+  // allowAll targets can match any command that has URL args
+  const hasAllowAll = targets.some(t => t.allowAll);
+  if (!hasAllowAll && !ENDPOINT_COMMANDS.has(cmd.command)) return null;
+
+  const urls = extractURLs(cmd);
+  if (urls.length === 0) return null;
+
+  let bestMatch: CommandEvalDetail | null = null;
+
+  for (const target of targets) {
+    if (!target.allowAll && target.commands && target.commands.length > 0 && !target.commands.includes(cmd.command)) {
+      continue;
+    }
+
+    for (const url of urls) {
+      if (globToRegex(target.pattern).test(url)) {
+        const decision = target.allowAll ? 'allow' as const : target.decision;
+        const detail: CommandEvalDetail = {
+          command: cmd.command,
+          args: cmd.args,
+          decision,
+          reason: target.reason || `URL "${url}" matches trusted endpoint "${target.pattern}" (${decision})`,
+          matchedRule: 'trustedEndpoints',
+        };
+
+        if (decision === 'deny') return detail;
+        if (!bestMatch) bestMatch = detail;
+      }
+    }
+  }
+
+  return bestMatch;
+}
+
+export function evaluateTargetPolicies(
+  cmd: ParsedCommand,
+  cwd: string,
+  config: WardenConfig,
+): CommandEvalDetail | null {
+  const policies = config.targetPolicies;
+  if (!policies?.length) return null;
+
+  const results: CommandEvalDetail[] = [];
+
+  const pathPolicies = policies.filter((p): p is PathPolicy => p.type === 'path');
+  if (pathPolicies.length) {
+    const r = evaluatePathTarget(cmd, cwd, pathPolicies);
+    if (r) results.push(r);
+  }
+
+  const dbPolicies = policies.filter((p): p is DatabasePolicy => p.type === 'database');
+  if (dbPolicies.length) {
+    const r = evaluateDatabaseTarget(cmd, dbPolicies);
+    if (r) results.push(r);
+  }
+
+  const endpointPolicies = policies.filter((p): p is EndpointPolicy => p.type === 'endpoint');
+  if (endpointPolicies.length) {
+    const r = evaluateEndpointTarget(cmd, endpointPolicies);
+    if (r) results.push(r);
+  }
+
+  if (results.length === 0) return null;
+
+  // Deny takes precedence
+  const deny = results.find(r => r.decision === 'deny');
+  if (deny) return deny;
+
+  return results[0];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,13 +55,45 @@ export interface TrustedTarget {
   overrides?: ConfigLayer;
 }
 
+// Remote contexts — extends TrustedTarget with a discriminator
+export type RemoteContext = 'ssh' | 'docker' | 'kubectl' | 'sprite' | 'fly';
+
+export interface TrustedRemote extends TrustedTarget {
+  context: RemoteContext;
+}
+
+// Data targets — discriminated union
+export type TargetPolicy = PathPolicy | DatabasePolicy | EndpointPolicy;
+
+interface TargetPolicyBase {
+  commands?: string[];
+  decision: Decision;
+  reason?: string;
+  allowAll?: boolean;
+}
+
+export interface PathPolicy extends TargetPolicyBase {
+  type: 'path';
+  path: string;
+  recursive?: boolean;
+}
+
+export interface DatabasePolicy extends TargetPolicyBase {
+  type: 'database';
+  host: string;
+  port?: number;
+  database?: string;
+}
+
+export interface EndpointPolicy extends TargetPolicyBase {
+  type: 'endpoint';
+  pattern: string;
+}
+
 export interface WardenConfig {
   layers: ConfigLayer[];
-  trustedSSHHosts?: TrustedTarget[];
-  trustedDockerContainers?: TrustedTarget[];
-  trustedKubectlContexts?: TrustedTarget[];
-  trustedSprites?: TrustedTarget[];
-  trustedFlyApps?: TrustedTarget[];
+  trustedRemotes?: TrustedRemote[];
+  targetPolicies?: TargetPolicy[];
   trustedContextOverrides?: ConfigLayer;
   defaultDecision: Decision;
   askOnSubshell: boolean;


### PR DESCRIPTION
## Summary

Implements data-aware security policies (#61) — a unified `targetPolicies` framework that lets users declare trusted **targets** (filesystem paths, database connections, network endpoints) so warden can conditionally override decisions based on *what data a command operates on*, not just the command name.

- **Path policies**: Auto-allow/deny commands targeting specific filesystem paths (e.g., `rm -rf /tmp/build` is safe, `rm -rf /etc` is not). Supports `{{cwd}}` templates, recursive matching, and command filtering.
- **Database policies**: Match database CLI commands (`psql`, `mysql`, `redis-cli`, `mongosh`) by host/port/database extracted from flags and connection strings. 
- **Endpoint policies**: Match HTTP commands (`curl`, `wget`) by URL pattern with glob matching.
- **Unified config**: Replaces the separate `trustedSSHHosts`/`trustedDockerContainers`/`trustedKubectlContexts`/`trustedSprites`/`trustedFlyApps` with a single `trustedRemotes` array using `context` + `name` fields (backward compatible via migration in `rules.ts`).

### New modules
- `src/targets.ts` — Target resolution and policy evaluation for path/database/endpoint targets
- `src/glob.ts` — Lightweight glob-to-regex converter (supports `*`, `?`, `[...]`, `{a,b}`)
- `src/__tests__/targets.test.ts` — Comprehensive tests for all target policy types

### Evaluation flow change
Target-based overrides are evaluated **after** `alwaysDeny`/`alwaysAllow` but **before** command-specific rules, so `alwaysDeny` still blocks unconditionally while target policies can override what would otherwise be an `ask`.

Closes #61

## Test plan

- [x] New `targets.test.ts` covers path, database, and endpoint policies
- [x] Updated `evaluator.test.ts` for new unified `trustedRemotes` config
- [x] Updated `integration.test.ts` for config format changes
- [ ] `pnpm run test` passes all tests
- [ ] `pnpm run typecheck` passes
- [ ] Manual testing with sample `warden.yaml` configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)