### PR TITLE
fix(ci): use npx npm@11.5.1 for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,8 +20,7 @@ jobs:
           node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org
-      - run: npm install -g npm@latest
       - run: pnpm install --frozen-lockfile
       - run: pnpm run test
       - run: pnpm run build
-      - run: npm publish --access public --provenance
+      - run: npx -y npm@11.5.1 publish --access public --provenance


### PR DESCRIPTION
Global self-upgrade of npm corrupted the install. Use npx to run a pinned npm version that supports trusted publisher OIDC.