### PR TITLE
fix: run hook script directly instead of via node

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Smart command safety filter for Claude Code — parses shell pipelines and evaluates per-command safety rules to auto-approve safe commands and block dangerous ones",
   "author": {
     "name": "banyudu"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/dist/index.cjs",
+            "command": "${CLAUDE_PLUGIN_ROOT}/dist/index.cjs",
             "timeout": 5
           }
         ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-warden",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Smart command safety filter for Claude Code — auto-approves safe commands, blocks dangerous ones",
   "type": "module",
   "main": "dist/index.cjs",
@@ -36,7 +36,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && chmod +x dist/*.cjs",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -48,7 +48,7 @@
     "release": "scripts/release.sh patch",
     "release:minor": "scripts/release.sh minor",
     "release:major": "scripts/release.sh major",
-    "prepublishOnly": "pnpm run sync-plugin-version && pnpm run build && pnpm run test",
+    "prepublishOnly": "pnpm run sync-plugin-version && pnpm run build && pnpm run test && chmod +x dist/*.cjs",
     "postpublish": "claude plugin update claude-warden@local 2>/dev/null; claude plugin update warden@claude-warden 2>/dev/null; echo 'Plugin caches updated'",
     "docs:dev": "cd docs-src && pnpm dev",
     "docs:build": "cd docs-src && pnpm install && pnpm build"


### PR DESCRIPTION
## Summary
- Remove `node` prefix from hook command — `dist/index.cjs` has a shebang so it runs directly
- Add `chmod +x` to build and prepublishOnly scripts so the output is executable
- Bump version to 2.5.1

## Test plan
- [x] All 487 tests pass
- [x] Build produces executable `dist/index.cjs` with shebang

🤖 Generated with [Claude Code](https://claude.com/claude-code)