### PR TITLE
feat: allow common script aliases and pnpm workspace flags

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "warden",
       "description": "Auto-approves safe commands, blocks dangerous ones, prompts for the rest",
-      "version": "2.5.0",
+      "version": "2.5.2",
       "author": {
         "name": "banyudu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Smart command safety filter for Claude Code — parses shell pipelines and evaluates per-command safety rules to auto-approve safe commands and block dangerous ones",
   "author": {
     "name": "banyudu"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-warden",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Smart command safety filter for Claude Code — auto-approves safe commands, blocks dangerous ones",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -22,6 +22,9 @@ const SAFE_PKG_MANAGER_CMDS = [
   'ls', 'list', 'run', 'test', 'start', 'build', 'init', 'create',
   'info', 'view', 'show', 'why', 'pack', 'cache', 'config', 'get', 'set',
   'version', 'help', 'exec', 'dedupe', 'prune', 'audit', 'completion', 'whoami',
+  // Common script aliases (run implicitly by npm/pnpm/yarn/bun)
+  'typecheck', 'type-check', 'lint', 'format', 'check', 'check-types',
+  'test:unit', 'test:e2e', 'test:watch', 'lint:fix',
 ];
 
 const VERSION_HELP_FLAGS: ArgPattern = {
@@ -230,7 +233,7 @@ export const DEFAULT_CONFIG: WardenConfig = {
       pkgRunnerRule('pnpx'),
       // npm / pnpm / yarn — package managers
       pkgManagerRule('npm', ['ci', 'search', 'explain', 'prefix', 'root', 'fund', 'doctor', 'diff', 'pkg', 'query', 'shrinkwrap']),
-      pkgManagerRule('pnpm', ['store', 'fetch', 'doctor', 'patch']),
+      pkgManagerRule('pnpm', ['store', 'fetch', 'doctor', 'patch', '--filter', '-F', '--recursive', '-r', '--workspace-root', '-w']),
       pkgManagerRule('yarn', ['up', 'dlx', 'workspaces']),
       // bun — runtime + package manager
       {


### PR DESCRIPTION
## Summary
- Add `typecheck`, `type-check`, `lint`, `format`, `check`, `check-types`, `test:unit`, `test:e2e`, `test:watch`, `lint:fix` to `SAFE_PKG_MANAGER_CMDS` so `pnpm typecheck` / `npm run lint` auto-allow across npm/pnpm/yarn/bun
- Whitelist pnpm workspace flags (`--filter`/`-F`, `--recursive`/`-r`, `--workspace-root`/`-w`) so `pnpm --filter foo build` stops prompting
- Bump to 2.5.2 (package.json, plugin.json, marketplace.json)

## Test plan
- [x] `pnpm test` — 487 passed