### PR TITLE
fix: allow implicit dev tool execution via pnpm/yarn

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -73,6 +73,7 @@ function pkgManagerRule(command: string, extraSafeCmds: string[] = []): CommandR
         decision: 'allow',
         description: `Standard ${command} commands`,
       },
+      safeDevToolsPattern(),
       VERSION_HELP_FLAGS,
     ],
   };


### PR DESCRIPTION
## Summary
- `pnpm jest auth.controller --coverage=false` (and similar pnpm/yarn shortcuts) was falling through to `ask` because `SAFE_PKG_MANAGER_CMDS` only covers package manager subcommands.
- pnpm/yarn support implicit script and `node_modules/.bin` execution without `run` — this adds `safeDevToolsPattern()` to `pkgManagerRule` so well-known dev tools (jest, vitest, eslint, tsc, prettier, ...) are allowed as direct args, matching how the bun rule already behaves.

## Test plan
- [x] `pnpm run test` — all 487 tests pass
- [ ] Manual: `pnpm jest foo` no longer prompts
- [ ] Manual: `pnpm vitest`, `pnpm eslint .`, `yarn tsc` allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)