### PR TITLE
v2.5.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "warden",
       "description": "Auto-approves safe commands, blocks dangerous ones, prompts for the rest",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "author": {
         "name": "banyudu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Smart command safety filter for Claude Code — parses shell pipelines and evaluates per-command safety rules to auto-approve safe commands and block dangerous ones",
   "author": {
     "name": "banyudu"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-warden",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Smart command safety filter for Claude Code — auto-approves safe commands, blocks dangerous ones",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary
- Allow implicit dev tool execution via pnpm/yarn (e.g. `pnpm tsc`, `yarn vitest`) without prompting

## Test plan
- [x] Manifests bumped to 2.5.3