### PR TITLE
chore: release v2.5.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Smart command safety filter for Claude Code — parses shell pipelines and evaluates per-command safety rules to auto-approve safe commands and block dangerous ones",
   "author": {
     "name": "banyudu"

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -18818,7 +18818,18 @@ var SAFE_PKG_MANAGER_CMDS = [
   "prune",
   "audit",
   "completion",
-  "whoami"
+  "whoami",
+  // Common script aliases (run implicitly by npm/pnpm/yarn/bun)
+  "typecheck",
+  "type-check",
+  "lint",
+  "format",
+  "check",
+  "check-types",
+  "test:unit",
+  "test:e2e",
+  "test:watch",
+  "lint:fix"
 ];
 var VERSION_HELP_FLAGS = {
   match: { anyArgMatches: ["^--(version|help)$", "^-[vh]$"] },
@@ -18861,6 +18872,7 @@ function pkgManagerRule(command, extraSafeCmds = []) {
         decision: "allow",
         description: `Standard ${command} commands`
       },
+      safeDevToolsPattern(),
       VERSION_HELP_FLAGS
     ]
   };
@@ -19184,7 +19196,7 @@ var DEFAULT_CONFIG = {
       pkgRunnerRule("pnpx"),
       // npm / pnpm / yarn — package managers
       pkgManagerRule("npm", ["ci", "search", "explain", "prefix", "root", "fund", "doctor", "diff", "pkg", "query", "shrinkwrap"]),
-      pkgManagerRule("pnpm", ["store", "fetch", "doctor", "patch"]),
+      pkgManagerRule("pnpm", ["store", "fetch", "doctor", "patch", "--filter", "-F", "--recursive", "-r", "--workspace-root", "-w"]),
       pkgManagerRule("yarn", ["up", "dlx", "workspaces"]),
       // bun — runtime + package manager
       {

--- a/dist/codex-export.cjs
+++ b/dist/codex-export.cjs
@@ -18822,7 +18822,18 @@ var SAFE_PKG_MANAGER_CMDS = [
   "prune",
   "audit",
   "completion",
-  "whoami"
+  "whoami",
+  // Common script aliases (run implicitly by npm/pnpm/yarn/bun)
+  "typecheck",
+  "type-check",
+  "lint",
+  "format",
+  "check",
+  "check-types",
+  "test:unit",
+  "test:e2e",
+  "test:watch",
+  "lint:fix"
 ];
 var VERSION_HELP_FLAGS = {
   match: { anyArgMatches: ["^--(version|help)$", "^-[vh]$"] },
@@ -18865,6 +18876,7 @@ function pkgManagerRule(command, extraSafeCmds = []) {
         decision: "allow",
         description: `Standard ${command} commands`
       },
+      safeDevToolsPattern(),
       VERSION_HELP_FLAGS
     ]
   };
@@ -19188,7 +19200,7 @@ var DEFAULT_CONFIG = {
       pkgRunnerRule("pnpx"),
       // npm / pnpm / yarn — package managers
       pkgManagerRule("npm", ["ci", "search", "explain", "prefix", "root", "fund", "doctor", "diff", "pkg", "query", "shrinkwrap"]),
-      pkgManagerRule("pnpm", ["store", "fetch", "doctor", "patch"]),
+      pkgManagerRule("pnpm", ["store", "fetch", "doctor", "patch", "--filter", "-F", "--recursive", "-r", "--workspace-root", "-w"]),
       pkgManagerRule("yarn", ["up", "dlx", "workspaces"]),
       // bun — runtime + package manager
       {

--- a/dist/copilot.cjs
+++ b/dist/copilot.cjs
@@ -18818,7 +18818,18 @@ var SAFE_PKG_MANAGER_CMDS = [
   "prune",
   "audit",
   "completion",
-  "whoami"
+  "whoami",
+  // Common script aliases (run implicitly by npm/pnpm/yarn/bun)
+  "typecheck",
+  "type-check",
+  "lint",
+  "format",
+  "check",
+  "check-types",
+  "test:unit",
+  "test:e2e",
+  "test:watch",
+  "lint:fix"
 ];
 var VERSION_HELP_FLAGS = {
   match: { anyArgMatches: ["^--(version|help)$", "^-[vh]$"] },
@@ -18861,6 +18872,7 @@ function pkgManagerRule(command, extraSafeCmds = []) {
         decision: "allow",
         description: `Standard ${command} commands`
       },
+      safeDevToolsPattern(),
       VERSION_HELP_FLAGS
     ]
   };
@@ -19184,7 +19196,7 @@ var DEFAULT_CONFIG = {
       pkgRunnerRule("pnpx"),
       // npm / pnpm / yarn — package managers
       pkgManagerRule("npm", ["ci", "search", "explain", "prefix", "root", "fund", "doctor", "diff", "pkg", "query", "shrinkwrap"]),
-      pkgManagerRule("pnpm", ["store", "fetch", "doctor", "patch"]),
+      pkgManagerRule("pnpm", ["store", "fetch", "doctor", "patch", "--filter", "-F", "--recursive", "-r", "--workspace-root", "-w"]),
       pkgManagerRule("yarn", ["up", "dlx", "workspaces"]),
       // bun — runtime + package manager
       {

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -18818,7 +18818,18 @@ var SAFE_PKG_MANAGER_CMDS = [
   "prune",
   "audit",
   "completion",
-  "whoami"
+  "whoami",
+  // Common script aliases (run implicitly by npm/pnpm/yarn/bun)
+  "typecheck",
+  "type-check",
+  "lint",
+  "format",
+  "check",
+  "check-types",
+  "test:unit",
+  "test:e2e",
+  "test:watch",
+  "lint:fix"
 ];
 var VERSION_HELP_FLAGS = {
   match: { anyArgMatches: ["^--(version|help)$", "^-[vh]$"] },
@@ -18861,6 +18872,7 @@ function pkgManagerRule(command, extraSafeCmds = []) {
         decision: "allow",
         description: `Standard ${command} commands`
       },
+      safeDevToolsPattern(),
       VERSION_HELP_FLAGS
     ]
   };
@@ -19184,7 +19196,7 @@ var DEFAULT_CONFIG = {
       pkgRunnerRule("pnpx"),
       // npm / pnpm / yarn — package managers
       pkgManagerRule("npm", ["ci", "search", "explain", "prefix", "root", "fund", "doctor", "diff", "pkg", "query", "shrinkwrap"]),
-      pkgManagerRule("pnpm", ["store", "fetch", "doctor", "patch"]),
+      pkgManagerRule("pnpm", ["store", "fetch", "doctor", "patch", "--filter", "-F", "--recursive", "-r", "--workspace-root", "-w"]),
       pkgManagerRule("yarn", ["up", "dlx", "workspaces"]),
       // bun — runtime + package manager
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-warden",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Smart command safety filter for Claude Code — auto-approves safe commands, blocks dangerous ones",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
Rebuild dist to include pnpm implicit dev tool execution fix (from #90) that was missing from the v2.5.3 release artifacts.