### PR TITLE
chore: release v2.7.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Smart command safety filter for Claude Code — parses shell pipelines and evaluates per-command safety rules to auto-approve safe commands and block dangerous ones",
   "author": {
     "name": "banyudu"

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -18892,13 +18892,42 @@ var DEFAULT_SKILL_RULES = {
   defaultDecision: "ask",
   layers: [{
     alwaysAllow: [
-      "commit",
+      // Built-in review/analysis skills
       "review",
-      "simplify",
-      "init",
-      "commit-commands:commit",
-      "commit-commands:commit-push-pr",
-      "code-review:code-review"
+      "security-review",
+      // Code review plugins
+      "code-review:code-review",
+      "pr-review-toolkit:review-pr",
+      // Slack read-only skills
+      "slack:find-discussions",
+      "slack:summarize-channel",
+      "slack:channel-digest",
+      "slack:standup",
+      "slack:draft-announcement",
+      "slack:slack-messaging",
+      "slack:slack-search",
+      // Search/summarization
+      "promptfolio-summarize",
+      "promptfolio-search-skills",
+      "promptfolio-search-people",
+      // Informational/guidance skills
+      "keybindings-help",
+      "claude-api",
+      "azure-tools:azure-usage",
+      "gcloud-tools:gcloud-usage",
+      "linear-tools:linear-usage",
+      "tavily-tools:tavily-usage",
+      "mongodb-tools:mongodb-usage",
+      "supabase-tools:supabase-usage",
+      "playwright-tools:playwright-testing",
+      // Plugin development guidance (read-only context loading)
+      "plugin-dev:agent-development",
+      "plugin-dev:mcp-integration",
+      "plugin-dev:skill-development",
+      "plugin-dev:plugin-settings",
+      "plugin-dev:command-development",
+      "plugin-dev:plugin-structure",
+      "plugin-dev:hook-development"
     ],
     alwaysDeny: [],
     rules: []

--- a/dist/codex-export.cjs
+++ b/dist/codex-export.cjs
@@ -18896,13 +18896,42 @@ var DEFAULT_SKILL_RULES = {
   defaultDecision: "ask",
   layers: [{
     alwaysAllow: [
-      "commit",
+      // Built-in review/analysis skills
       "review",
-      "simplify",
-      "init",
-      "commit-commands:commit",
-      "commit-commands:commit-push-pr",
-      "code-review:code-review"
+      "security-review",
+      // Code review plugins
+      "code-review:code-review",
+      "pr-review-toolkit:review-pr",
+      // Slack read-only skills
+      "slack:find-discussions",
+      "slack:summarize-channel",
+      "slack:channel-digest",
+      "slack:standup",
+      "slack:draft-announcement",
+      "slack:slack-messaging",
+      "slack:slack-search",
+      // Search/summarization
+      "promptfolio-summarize",
+      "promptfolio-search-skills",
+      "promptfolio-search-people",
+      // Informational/guidance skills
+      "keybindings-help",
+      "claude-api",
+      "azure-tools:azure-usage",
+      "gcloud-tools:gcloud-usage",
+      "linear-tools:linear-usage",
+      "tavily-tools:tavily-usage",
+      "mongodb-tools:mongodb-usage",
+      "supabase-tools:supabase-usage",
+      "playwright-tools:playwright-testing",
+      // Plugin development guidance (read-only context loading)
+      "plugin-dev:agent-development",
+      "plugin-dev:mcp-integration",
+      "plugin-dev:skill-development",
+      "plugin-dev:plugin-settings",
+      "plugin-dev:command-development",
+      "plugin-dev:plugin-structure",
+      "plugin-dev:hook-development"
     ],
     alwaysDeny: [],
     rules: []

--- a/dist/copilot.cjs
+++ b/dist/copilot.cjs
@@ -18892,13 +18892,42 @@ var DEFAULT_SKILL_RULES = {
   defaultDecision: "ask",
   layers: [{
     alwaysAllow: [
-      "commit",
+      // Built-in review/analysis skills
       "review",
-      "simplify",
-      "init",
-      "commit-commands:commit",
-      "commit-commands:commit-push-pr",
-      "code-review:code-review"
+      "security-review",
+      // Code review plugins
+      "code-review:code-review",
+      "pr-review-toolkit:review-pr",
+      // Slack read-only skills
+      "slack:find-discussions",
+      "slack:summarize-channel",
+      "slack:channel-digest",
+      "slack:standup",
+      "slack:draft-announcement",
+      "slack:slack-messaging",
+      "slack:slack-search",
+      // Search/summarization
+      "promptfolio-summarize",
+      "promptfolio-search-skills",
+      "promptfolio-search-people",
+      // Informational/guidance skills
+      "keybindings-help",
+      "claude-api",
+      "azure-tools:azure-usage",
+      "gcloud-tools:gcloud-usage",
+      "linear-tools:linear-usage",
+      "tavily-tools:tavily-usage",
+      "mongodb-tools:mongodb-usage",
+      "supabase-tools:supabase-usage",
+      "playwright-tools:playwright-testing",
+      // Plugin development guidance (read-only context loading)
+      "plugin-dev:agent-development",
+      "plugin-dev:mcp-integration",
+      "plugin-dev:skill-development",
+      "plugin-dev:plugin-settings",
+      "plugin-dev:command-development",
+      "plugin-dev:plugin-structure",
+      "plugin-dev:hook-development"
     ],
     alwaysDeny: [],
     rules: []

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -18892,13 +18892,42 @@ var DEFAULT_SKILL_RULES = {
   defaultDecision: "ask",
   layers: [{
     alwaysAllow: [
-      "commit",
+      // Built-in review/analysis skills
       "review",
-      "simplify",
-      "init",
-      "commit-commands:commit",
-      "commit-commands:commit-push-pr",
-      "code-review:code-review"
+      "security-review",
+      // Code review plugins
+      "code-review:code-review",
+      "pr-review-toolkit:review-pr",
+      // Slack read-only skills
+      "slack:find-discussions",
+      "slack:summarize-channel",
+      "slack:channel-digest",
+      "slack:standup",
+      "slack:draft-announcement",
+      "slack:slack-messaging",
+      "slack:slack-search",
+      // Search/summarization
+      "promptfolio-summarize",
+      "promptfolio-search-skills",
+      "promptfolio-search-people",
+      // Informational/guidance skills
+      "keybindings-help",
+      "claude-api",
+      "azure-tools:azure-usage",
+      "gcloud-tools:gcloud-usage",
+      "linear-tools:linear-usage",
+      "tavily-tools:tavily-usage",
+      "mongodb-tools:mongodb-usage",
+      "supabase-tools:supabase-usage",
+      "playwright-tools:playwright-testing",
+      // Plugin development guidance (read-only context loading)
+      "plugin-dev:agent-development",
+      "plugin-dev:mcp-integration",
+      "plugin-dev:skill-development",
+      "plugin-dev:plugin-settings",
+      "plugin-dev:command-development",
+      "plugin-dev:plugin-structure",
+      "plugin-dev:hook-development"
     ],
     alwaysDeny: [],
     rules: []

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-warden",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Smart command safety filter for Claude Code — auto-approves safe commands, blocks dangerous ones",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Release v2.7.0

### Features
- Support Skill tool filtering via PreToolUse hook (#95)
- Restrict default skill whitelist to read-only skills only

### Docs
- Replace bd:* examples with generic example-plugin:* namespace