### PR TITLE
feat: inject plugin-level guidance via SessionStart hook (#96)

### DIFF
--- a/config/warden.default.yaml
+++ b/config/warden.default.yaml
@@ -23,15 +23,21 @@ notifyOnDeny: true
 # Claude sees this as a system message, so it can shape tool choice *before*
 # warden needs to ask or deny. Keep it short — it competes for context.
 #
-# - Omit the key to use the built-in default (prefer jq, save scripts to files,
-#   read deny reasons, mention /warden:allow and /warden:yolo).
+# - Omit the key to use the built-in default (prefer jq, save temp scripts to
+#   tempScriptDir below, read deny reasons, mention /warden:allow and /warden:yolo).
 # - Set to a string to override with your own guidance.
 # - Set to `false` to disable injection entirely.
 #
 # sessionGuidance: |
 #   Warden is active. Prefer allow-listed tools (e.g. jq for JSON). For
-#   multi-line logic, save a script under scripts/*.sh instead of using
+#   multi-line logic, save a temp script under /tmp/ instead of using
 #   inline `bash -c` / `node -e`.
+
+# Directory the built-in guidance tells Claude to save throwaway multi-line
+# scripts to. Defaults to `/tmp` so scripts don't pollute the repo. Point at
+# another location (e.g. `.warden-scratch`) if you want them tracked per-project.
+# Only used when `sessionGuidance` is unset.
+# tempScriptDir: /tmp
 
 # Additional commands to always allow (checked after alwaysDeny within this scope)
 # alwaysAllow:

--- a/config/warden.default.yaml
+++ b/config/warden.default.yaml
@@ -19,6 +19,20 @@ askOnSubshell: true
 notifyOnAsk: true
 notifyOnDeny: true
 
+# Guidance injected into every Claude Code session via the SessionStart hook.
+# Claude sees this as a system message, so it can shape tool choice *before*
+# warden needs to ask or deny. Keep it short — it competes for context.
+#
+# - Omit the key to use the built-in default (prefer jq, save scripts to files,
+#   read deny reasons, mention /warden:allow and /warden:yolo).
+# - Set to a string to override with your own guidance.
+# - Set to `false` to disable injection entirely.
+#
+# sessionGuidance: |
+#   Warden is active. Prefer allow-listed tools (e.g. jq for JSON). For
+#   multi-line logic, save a script under scripts/*.sh instead of using
+#   inline `bash -c` / `node -e`.
+
 # Additional commands to always allow (checked after alwaysDeny within this scope)
 # alwaysAllow:
 #   - terraform

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -18933,6 +18933,14 @@ var DEFAULT_SKILL_RULES = {
     rules: []
   }]
 };
+var DEFAULT_SESSION_GUIDANCE = [
+  "Claude Warden is active. It filters Bash commands against safety rules and may ask or deny.",
+  "",
+  "- For JSON in shell pipelines, prefer `jq` (auto-allowed) over `python3 -c` / `node -e`.",
+  "- For multi-line logic, save a script to `scripts/*.sh` or add a `package.json` script rather than inline `bash -c` / `node -e`.",
+  "- When Warden denies or asks, read the reason \u2014 it often names the preferred alternative.",
+  "- To permanently allow a specific command, run `/warden:allow <cmd>`. To temporarily bypass filtering, `/warden:yolo`."
+].join("\n");
 var DEFAULT_CONFIG = {
   defaultDecision: "ask",
   askOnSubshell: true,
@@ -19808,6 +19816,12 @@ function mergeNonLayerFields(config, raw) {
   }
   if (typeof raw.notifyOnDeny === "boolean") {
     config.notifyOnDeny = raw.notifyOnDeny;
+  }
+  if (typeof raw.sessionGuidance === "string" || raw.sessionGuidance === false) {
+    config.sessionGuidance = raw.sessionGuidance;
+  } else if (raw.sessionGuidance !== void 0) {
+    warn(`[warden] Warning: invalid sessionGuidance (expected string or false), ignoring
+`);
   }
   if (raw.skills && typeof raw.skills === "object") {
     const skills = raw.skills;

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -18933,14 +18933,18 @@ var DEFAULT_SKILL_RULES = {
     rules: []
   }]
 };
-var DEFAULT_SESSION_GUIDANCE = [
-  "Claude Warden is active. It filters Bash commands against safety rules and may ask or deny.",
-  "",
-  "- For JSON in shell pipelines, prefer `jq` (auto-allowed) over `python3 -c` / `node -e`.",
-  "- For multi-line logic, save a script to `scripts/*.sh` or add a `package.json` script rather than inline `bash -c` / `node -e`.",
-  "- When Warden denies or asks, read the reason \u2014 it often names the preferred alternative.",
-  "- To permanently allow a specific command, run `/warden:allow <cmd>`. To temporarily bypass filtering, `/warden:yolo`."
-].join("\n");
+var DEFAULT_TEMP_SCRIPT_DIR = "/tmp";
+function buildDefaultSessionGuidance(tempScriptDir) {
+  return [
+    "Claude Warden is active. It filters Bash commands against safety rules and may ask or deny.",
+    "",
+    "- For JSON in shell pipelines, prefer `jq` (auto-allowed) over `python3 -c` / `node -e`.",
+    `- For multi-line logic, save a temp script under \`${tempScriptDir}/\` (e.g. \`${tempScriptDir}/warden-task.sh\`) or add a \`package.json\` script rather than inline \`bash -c\` / \`node -e\`. Avoid polluting the repo with throwaway scripts.`,
+    "- When Warden denies or asks, read the reason \u2014 it often names the preferred alternative.",
+    "- To permanently allow a specific command, run `/warden:allow <cmd>`. To temporarily bypass filtering, `/warden:yolo`."
+  ].join("\n");
+}
+var DEFAULT_SESSION_GUIDANCE = buildDefaultSessionGuidance(DEFAULT_TEMP_SCRIPT_DIR);
 var DEFAULT_CONFIG = {
   defaultDecision: "ask",
   askOnSubshell: true,
@@ -19821,6 +19825,12 @@ function mergeNonLayerFields(config, raw) {
     config.sessionGuidance = raw.sessionGuidance;
   } else if (raw.sessionGuidance !== void 0) {
     warn(`[warden] Warning: invalid sessionGuidance (expected string or false), ignoring
+`);
+  }
+  if (typeof raw.tempScriptDir === "string" && raw.tempScriptDir.length > 0) {
+    config.tempScriptDir = raw.tempScriptDir;
+  } else if (raw.tempScriptDir !== void 0) {
+    warn(`[warden] Warning: invalid tempScriptDir (expected non-empty string), ignoring
 `);
   }
   if (raw.skills && typeof raw.skills === "object") {

--- a/dist/codex-export.cjs
+++ b/dist/codex-export.cjs
@@ -18937,6 +18937,14 @@ var DEFAULT_SKILL_RULES = {
     rules: []
   }]
 };
+var DEFAULT_SESSION_GUIDANCE = [
+  "Claude Warden is active. It filters Bash commands against safety rules and may ask or deny.",
+  "",
+  "- For JSON in shell pipelines, prefer `jq` (auto-allowed) over `python3 -c` / `node -e`.",
+  "- For multi-line logic, save a script to `scripts/*.sh` or add a `package.json` script rather than inline `bash -c` / `node -e`.",
+  "- When Warden denies or asks, read the reason \u2014 it often names the preferred alternative.",
+  "- To permanently allow a specific command, run `/warden:allow <cmd>`. To temporarily bypass filtering, `/warden:yolo`."
+].join("\n");
 var DEFAULT_CONFIG = {
   defaultDecision: "ask",
   askOnSubshell: true,
@@ -19812,6 +19820,12 @@ function mergeNonLayerFields(config, raw) {
   }
   if (typeof raw.notifyOnDeny === "boolean") {
     config.notifyOnDeny = raw.notifyOnDeny;
+  }
+  if (typeof raw.sessionGuidance === "string" || raw.sessionGuidance === false) {
+    config.sessionGuidance = raw.sessionGuidance;
+  } else if (raw.sessionGuidance !== void 0) {
+    warn(`[warden] Warning: invalid sessionGuidance (expected string or false), ignoring
+`);
   }
   if (raw.skills && typeof raw.skills === "object") {
     const skills = raw.skills;

--- a/dist/codex-export.cjs
+++ b/dist/codex-export.cjs
@@ -18937,14 +18937,18 @@ var DEFAULT_SKILL_RULES = {
     rules: []
   }]
 };
-var DEFAULT_SESSION_GUIDANCE = [
-  "Claude Warden is active. It filters Bash commands against safety rules and may ask or deny.",
-  "",
-  "- For JSON in shell pipelines, prefer `jq` (auto-allowed) over `python3 -c` / `node -e`.",
-  "- For multi-line logic, save a script to `scripts/*.sh` or add a `package.json` script rather than inline `bash -c` / `node -e`.",
-  "- When Warden denies or asks, read the reason \u2014 it often names the preferred alternative.",
-  "- To permanently allow a specific command, run `/warden:allow <cmd>`. To temporarily bypass filtering, `/warden:yolo`."
-].join("\n");
+var DEFAULT_TEMP_SCRIPT_DIR = "/tmp";
+function buildDefaultSessionGuidance(tempScriptDir) {
+  return [
+    "Claude Warden is active. It filters Bash commands against safety rules and may ask or deny.",
+    "",
+    "- For JSON in shell pipelines, prefer `jq` (auto-allowed) over `python3 -c` / `node -e`.",
+    `- For multi-line logic, save a temp script under \`${tempScriptDir}/\` (e.g. \`${tempScriptDir}/warden-task.sh\`) or add a \`package.json\` script rather than inline \`bash -c\` / \`node -e\`. Avoid polluting the repo with throwaway scripts.`,
+    "- When Warden denies or asks, read the reason \u2014 it often names the preferred alternative.",
+    "- To permanently allow a specific command, run `/warden:allow <cmd>`. To temporarily bypass filtering, `/warden:yolo`."
+  ].join("\n");
+}
+var DEFAULT_SESSION_GUIDANCE = buildDefaultSessionGuidance(DEFAULT_TEMP_SCRIPT_DIR);
 var DEFAULT_CONFIG = {
   defaultDecision: "ask",
   askOnSubshell: true,
@@ -19825,6 +19829,12 @@ function mergeNonLayerFields(config, raw) {
     config.sessionGuidance = raw.sessionGuidance;
   } else if (raw.sessionGuidance !== void 0) {
     warn(`[warden] Warning: invalid sessionGuidance (expected string or false), ignoring
+`);
+  }
+  if (typeof raw.tempScriptDir === "string" && raw.tempScriptDir.length > 0) {
+    config.tempScriptDir = raw.tempScriptDir;
+  } else if (raw.tempScriptDir !== void 0) {
+    warn(`[warden] Warning: invalid tempScriptDir (expected non-empty string), ignoring
 `);
   }
   if (raw.skills && typeof raw.skills === "object") {

--- a/dist/copilot.cjs
+++ b/dist/copilot.cjs
@@ -18933,14 +18933,18 @@ var DEFAULT_SKILL_RULES = {
     rules: []
   }]
 };
-var DEFAULT_SESSION_GUIDANCE = [
-  "Claude Warden is active. It filters Bash commands against safety rules and may ask or deny.",
-  "",
-  "- For JSON in shell pipelines, prefer `jq` (auto-allowed) over `python3 -c` / `node -e`.",
-  "- For multi-line logic, save a script to `scripts/*.sh` or add a `package.json` script rather than inline `bash -c` / `node -e`.",
-  "- When Warden denies or asks, read the reason \u2014 it often names the preferred alternative.",
-  "- To permanently allow a specific command, run `/warden:allow <cmd>`. To temporarily bypass filtering, `/warden:yolo`."
-].join("\n");
+var DEFAULT_TEMP_SCRIPT_DIR = "/tmp";
+function buildDefaultSessionGuidance(tempScriptDir) {
+  return [
+    "Claude Warden is active. It filters Bash commands against safety rules and may ask or deny.",
+    "",
+    "- For JSON in shell pipelines, prefer `jq` (auto-allowed) over `python3 -c` / `node -e`.",
+    `- For multi-line logic, save a temp script under \`${tempScriptDir}/\` (e.g. \`${tempScriptDir}/warden-task.sh\`) or add a \`package.json\` script rather than inline \`bash -c\` / \`node -e\`. Avoid polluting the repo with throwaway scripts.`,
+    "- When Warden denies or asks, read the reason \u2014 it often names the preferred alternative.",
+    "- To permanently allow a specific command, run `/warden:allow <cmd>`. To temporarily bypass filtering, `/warden:yolo`."
+  ].join("\n");
+}
+var DEFAULT_SESSION_GUIDANCE = buildDefaultSessionGuidance(DEFAULT_TEMP_SCRIPT_DIR);
 var DEFAULT_CONFIG = {
   defaultDecision: "ask",
   askOnSubshell: true,
@@ -19818,6 +19822,12 @@ function mergeNonLayerFields(config, raw) {
     config.sessionGuidance = raw.sessionGuidance;
   } else if (raw.sessionGuidance !== void 0) {
     warn(`[warden] Warning: invalid sessionGuidance (expected string or false), ignoring
+`);
+  }
+  if (typeof raw.tempScriptDir === "string" && raw.tempScriptDir.length > 0) {
+    config.tempScriptDir = raw.tempScriptDir;
+  } else if (raw.tempScriptDir !== void 0) {
+    warn(`[warden] Warning: invalid tempScriptDir (expected non-empty string), ignoring
 `);
   }
   if (raw.skills && typeof raw.skills === "object") {

--- a/dist/copilot.cjs
+++ b/dist/copilot.cjs
@@ -18933,6 +18933,14 @@ var DEFAULT_SKILL_RULES = {
     rules: []
   }]
 };
+var DEFAULT_SESSION_GUIDANCE = [
+  "Claude Warden is active. It filters Bash commands against safety rules and may ask or deny.",
+  "",
+  "- For JSON in shell pipelines, prefer `jq` (auto-allowed) over `python3 -c` / `node -e`.",
+  "- For multi-line logic, save a script to `scripts/*.sh` or add a `package.json` script rather than inline `bash -c` / `node -e`.",
+  "- When Warden denies or asks, read the reason \u2014 it often names the preferred alternative.",
+  "- To permanently allow a specific command, run `/warden:allow <cmd>`. To temporarily bypass filtering, `/warden:yolo`."
+].join("\n");
 var DEFAULT_CONFIG = {
   defaultDecision: "ask",
   askOnSubshell: true,
@@ -19805,6 +19813,12 @@ function mergeNonLayerFields(config, raw) {
   }
   if (typeof raw.notifyOnDeny === "boolean") {
     config.notifyOnDeny = raw.notifyOnDeny;
+  }
+  if (typeof raw.sessionGuidance === "string" || raw.sessionGuidance === false) {
+    config.sessionGuidance = raw.sessionGuidance;
+  } else if (raw.sessionGuidance !== void 0) {
+    warn(`[warden] Warning: invalid sessionGuidance (expected string or false), ignoring
+`);
   }
   if (raw.skills && typeof raw.skills === "object") {
     const skills = raw.skills;

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -18933,6 +18933,14 @@ var DEFAULT_SKILL_RULES = {
     rules: []
   }]
 };
+var DEFAULT_SESSION_GUIDANCE = [
+  "Claude Warden is active. It filters Bash commands against safety rules and may ask or deny.",
+  "",
+  "- For JSON in shell pipelines, prefer `jq` (auto-allowed) over `python3 -c` / `node -e`.",
+  "- For multi-line logic, save a script to `scripts/*.sh` or add a `package.json` script rather than inline `bash -c` / `node -e`.",
+  "- When Warden denies or asks, read the reason \u2014 it often names the preferred alternative.",
+  "- To permanently allow a specific command, run `/warden:allow <cmd>`. To temporarily bypass filtering, `/warden:yolo`."
+].join("\n");
 var DEFAULT_CONFIG = {
   defaultDecision: "ask",
   askOnSubshell: true,
@@ -19805,6 +19813,12 @@ function mergeNonLayerFields(config, raw) {
   }
   if (typeof raw.notifyOnDeny === "boolean") {
     config.notifyOnDeny = raw.notifyOnDeny;
+  }
+  if (typeof raw.sessionGuidance === "string" || raw.sessionGuidance === false) {
+    config.sessionGuidance = raw.sessionGuidance;
+  } else if (raw.sessionGuidance !== void 0) {
+    warn(`[warden] Warning: invalid sessionGuidance (expected string or false), ignoring
+`);
   }
   if (raw.skills && typeof raw.skills === "object") {
     const skills = raw.skills;
@@ -20990,6 +21004,18 @@ function emitDecision(decision, reason, stderrMessage) {
   }
   process.exit(0);
 }
+function handleSessionStart(config) {
+  if (config.sessionGuidance === false) process.exit(0);
+  const text = config.sessionGuidance ?? DEFAULT_SESSION_GUIDANCE;
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: text
+    }
+  };
+  process.stdout.write(JSON.stringify(output));
+  process.exit(0);
+}
 function handleYoloMode(sessionId, result) {
   const yoloState = getYoloState(sessionId);
   if (!yoloState) return;
@@ -21010,6 +21036,10 @@ async function main() {
     input = JSON.parse(raw);
   } catch {
     process.exit(0);
+  }
+  if (input.hook_event_name === "SessionStart") {
+    const config2 = loadConfig(input.cwd);
+    handleSessionStart(config2);
   }
   if (input.tool_name !== "Bash" && input.tool_name !== "Skill") {
     process.exit(0);

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -18933,14 +18933,18 @@ var DEFAULT_SKILL_RULES = {
     rules: []
   }]
 };
-var DEFAULT_SESSION_GUIDANCE = [
-  "Claude Warden is active. It filters Bash commands against safety rules and may ask or deny.",
-  "",
-  "- For JSON in shell pipelines, prefer `jq` (auto-allowed) over `python3 -c` / `node -e`.",
-  "- For multi-line logic, save a script to `scripts/*.sh` or add a `package.json` script rather than inline `bash -c` / `node -e`.",
-  "- When Warden denies or asks, read the reason \u2014 it often names the preferred alternative.",
-  "- To permanently allow a specific command, run `/warden:allow <cmd>`. To temporarily bypass filtering, `/warden:yolo`."
-].join("\n");
+var DEFAULT_TEMP_SCRIPT_DIR = "/tmp";
+function buildDefaultSessionGuidance(tempScriptDir) {
+  return [
+    "Claude Warden is active. It filters Bash commands against safety rules and may ask or deny.",
+    "",
+    "- For JSON in shell pipelines, prefer `jq` (auto-allowed) over `python3 -c` / `node -e`.",
+    `- For multi-line logic, save a temp script under \`${tempScriptDir}/\` (e.g. \`${tempScriptDir}/warden-task.sh\`) or add a \`package.json\` script rather than inline \`bash -c\` / \`node -e\`. Avoid polluting the repo with throwaway scripts.`,
+    "- When Warden denies or asks, read the reason \u2014 it often names the preferred alternative.",
+    "- To permanently allow a specific command, run `/warden:allow <cmd>`. To temporarily bypass filtering, `/warden:yolo`."
+  ].join("\n");
+}
+var DEFAULT_SESSION_GUIDANCE = buildDefaultSessionGuidance(DEFAULT_TEMP_SCRIPT_DIR);
 var DEFAULT_CONFIG = {
   defaultDecision: "ask",
   askOnSubshell: true,
@@ -19818,6 +19822,12 @@ function mergeNonLayerFields(config, raw) {
     config.sessionGuidance = raw.sessionGuidance;
   } else if (raw.sessionGuidance !== void 0) {
     warn(`[warden] Warning: invalid sessionGuidance (expected string or false), ignoring
+`);
+  }
+  if (typeof raw.tempScriptDir === "string" && raw.tempScriptDir.length > 0) {
+    config.tempScriptDir = raw.tempScriptDir;
+  } else if (raw.tempScriptDir !== void 0) {
+    warn(`[warden] Warning: invalid tempScriptDir (expected non-empty string), ignoring
 `);
   }
   if (raw.skills && typeof raw.skills === "object") {
@@ -21006,7 +21016,7 @@ function emitDecision(decision, reason, stderrMessage) {
 }
 function handleSessionStart(config) {
   if (config.sessionGuidance === false) process.exit(0);
-  const text = config.sessionGuidance ?? DEFAULT_SESSION_GUIDANCE;
+  const text = config.sessionGuidance ?? buildDefaultSessionGuidance(config.tempScriptDir ?? DEFAULT_TEMP_SCRIPT_DIR);
   const output = {
     hookSpecificOutput: {
       hookEventName: "SessionStart",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -22,6 +22,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/dist/index.cjs",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/src/__tests__/session-start.test.ts
+++ b/src/__tests__/session-start.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { resolve, join } from 'path';
+import { loadConfig } from '../rules';
+import { DEFAULT_SESSION_GUIDANCE } from '../defaults';
+
+const HOOK_BIN = resolve(__dirname, '../../dist/index.cjs');
+
+function makeWorkspace(yaml?: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'warden-session-'));
+  if (yaml !== undefined) {
+    mkdirSync(join(dir, '.claude'), { recursive: true });
+    writeFileSync(join(dir, '.claude', 'warden.yaml'), yaml);
+  }
+  return dir;
+}
+
+function runHook(
+  payload: object,
+  opts: { cwd: string; home: string },
+): { stdout: string; exitCode: number } {
+  try {
+    const stdout = execFileSync(process.execPath, [HOOK_BIN], {
+      input: JSON.stringify(payload),
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: opts.cwd,
+      env: { ...process.env, HOME: opts.home, USERPROFILE: opts.home },
+    });
+    return { stdout, exitCode: 0 };
+  } catch (err: any) {
+    return { stdout: err.stdout ?? '', exitCode: err.status ?? 1 };
+  }
+}
+
+describe('sessionGuidance config loading', () => {
+  let workspace: string | null = null;
+
+  afterEach(() => {
+    if (workspace) rmSync(workspace, { recursive: true, force: true });
+    workspace = null;
+  });
+
+  it('accepts a string override', () => {
+    workspace = makeWorkspace('sessionGuidance: "custom guidance"\n');
+    expect(loadConfig(workspace).sessionGuidance).toBe('custom guidance');
+  });
+
+  it('accepts `false` to disable', () => {
+    workspace = makeWorkspace('sessionGuidance: false\n');
+    expect(loadConfig(workspace).sessionGuidance).toBe(false);
+  });
+
+  it('ignores invalid types (number) and leaves it undefined', () => {
+    workspace = makeWorkspace('sessionGuidance: 42\n');
+    expect(loadConfig(workspace).sessionGuidance).toBeUndefined();
+  });
+});
+
+describe('SessionStart hook binary', () => {
+  let home: string | null = null;
+  let workspace: string | null = null;
+
+  afterEach(() => {
+    if (home) rmSync(home, { recursive: true, force: true });
+    if (workspace) rmSync(workspace, { recursive: true, force: true });
+    home = null;
+    workspace = null;
+  });
+
+  it('emits the built-in default guidance when no config is set', () => {
+    home = makeWorkspace();
+    workspace = makeWorkspace();
+    const { stdout, exitCode } = runHook(
+      {
+        session_id: 'test-1',
+        hook_event_name: 'SessionStart',
+        source: 'startup',
+        cwd: workspace,
+      },
+      { cwd: workspace, home },
+    );
+    expect(exitCode).toBe(0);
+    const output = JSON.parse(stdout);
+    expect(output.hookSpecificOutput.hookEventName).toBe('SessionStart');
+    expect(output.hookSpecificOutput.additionalContext).toBe(DEFAULT_SESSION_GUIDANCE);
+  });
+
+  it('emits user-provided guidance when config sets a string', () => {
+    home = makeWorkspace();
+    workspace = makeWorkspace('sessionGuidance: "use jq please"\n');
+    const { stdout, exitCode } = runHook(
+      {
+        session_id: 'test-2',
+        hook_event_name: 'SessionStart',
+        source: 'startup',
+        cwd: workspace,
+      },
+      { cwd: workspace, home },
+    );
+    expect(exitCode).toBe(0);
+    const output = JSON.parse(stdout);
+    expect(output.hookSpecificOutput.additionalContext).toBe('use jq please');
+  });
+
+  it('emits no output when sessionGuidance is false', () => {
+    home = makeWorkspace();
+    workspace = makeWorkspace('sessionGuidance: false\n');
+    const { stdout, exitCode } = runHook(
+      {
+        session_id: 'test-3',
+        hook_event_name: 'SessionStart',
+        source: 'startup',
+        cwd: workspace,
+      },
+      { cwd: workspace, home },
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe('');
+  });
+
+});

--- a/src/__tests__/session-start.test.ts
+++ b/src/__tests__/session-start.test.ts
@@ -58,6 +58,16 @@ describe('sessionGuidance config loading', () => {
     workspace = makeWorkspace('sessionGuidance: 42\n');
     expect(loadConfig(workspace).sessionGuidance).toBeUndefined();
   });
+
+  it('accepts a custom tempScriptDir', () => {
+    workspace = makeWorkspace('tempScriptDir: .warden-scratch\n');
+    expect(loadConfig(workspace).tempScriptDir).toBe('.warden-scratch');
+  });
+
+  it('ignores empty or invalid tempScriptDir', () => {
+    workspace = makeWorkspace('tempScriptDir: ""\n');
+    expect(loadConfig(workspace).tempScriptDir).toBeUndefined();
+  });
 });
 
 describe('SessionStart hook binary', () => {
@@ -87,6 +97,25 @@ describe('SessionStart hook binary', () => {
     const output = JSON.parse(stdout);
     expect(output.hookSpecificOutput.hookEventName).toBe('SessionStart');
     expect(output.hookSpecificOutput.additionalContext).toBe(DEFAULT_SESSION_GUIDANCE);
+    expect(output.hookSpecificOutput.additionalContext).toContain('/tmp/');
+  });
+
+  it('interpolates custom tempScriptDir into the default guidance', () => {
+    home = makeWorkspace();
+    workspace = makeWorkspace('tempScriptDir: .warden-scratch\n');
+    const { stdout, exitCode } = runHook(
+      {
+        session_id: 'test-tmp',
+        hook_event_name: 'SessionStart',
+        source: 'startup',
+        cwd: workspace,
+      },
+      { cwd: workspace, home },
+    );
+    expect(exitCode).toBe(0);
+    const output = JSON.parse(stdout);
+    expect(output.hookSpecificOutput.additionalContext).toContain('.warden-scratch/');
+    expect(output.hookSpecificOutput.additionalContext).not.toContain('/tmp/');
   });
 
   it('emits user-provided guidance when config sets a string', () => {

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -142,6 +142,15 @@ export const DEFAULT_SKILL_RULES: SkillRulesConfig = {
   }],
 };
 
+export const DEFAULT_SESSION_GUIDANCE = [
+  'Claude Warden is active. It filters Bash commands against safety rules and may ask or deny.',
+  '',
+  '- For JSON in shell pipelines, prefer `jq` (auto-allowed) over `python3 -c` / `node -e`.',
+  '- For multi-line logic, save a script to `scripts/*.sh` or add a `package.json` script rather than inline `bash -c` / `node -e`.',
+  '- When Warden denies or asks, read the reason — it often names the preferred alternative.',
+  '- To permanently allow a specific command, run `/warden:allow <cmd>`. To temporarily bypass filtering, `/warden:yolo`.',
+].join('\n');
+
 export const DEFAULT_CONFIG: WardenConfig = {
   defaultDecision: 'ask',
   askOnSubshell: true,

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -142,14 +142,20 @@ export const DEFAULT_SKILL_RULES: SkillRulesConfig = {
   }],
 };
 
-export const DEFAULT_SESSION_GUIDANCE = [
-  'Claude Warden is active. It filters Bash commands against safety rules and may ask or deny.',
-  '',
-  '- For JSON in shell pipelines, prefer `jq` (auto-allowed) over `python3 -c` / `node -e`.',
-  '- For multi-line logic, save a script to `scripts/*.sh` or add a `package.json` script rather than inline `bash -c` / `node -e`.',
-  '- When Warden denies or asks, read the reason — it often names the preferred alternative.',
-  '- To permanently allow a specific command, run `/warden:allow <cmd>`. To temporarily bypass filtering, `/warden:yolo`.',
-].join('\n');
+export const DEFAULT_TEMP_SCRIPT_DIR = '/tmp';
+
+export function buildDefaultSessionGuidance(tempScriptDir: string): string {
+  return [
+    'Claude Warden is active. It filters Bash commands against safety rules and may ask or deny.',
+    '',
+    '- For JSON in shell pipelines, prefer `jq` (auto-allowed) over `python3 -c` / `node -e`.',
+    `- For multi-line logic, save a temp script under \`${tempScriptDir}/\` (e.g. \`${tempScriptDir}/warden-task.sh\`) or add a \`package.json\` script rather than inline \`bash -c\` / \`node -e\`. Avoid polluting the repo with throwaway scripts.`,
+    '- When Warden denies or asks, read the reason — it often names the preferred alternative.',
+    '- To permanently allow a specific command, run `/warden:allow <cmd>`. To temporarily bypass filtering, `/warden:yolo`.',
+  ].join('\n');
+}
+
+export const DEFAULT_SESSION_GUIDANCE = buildDefaultSessionGuidance(DEFAULT_TEMP_SCRIPT_DIR);
 
 export const DEFAULT_CONFIG: WardenConfig = {
   defaultDecision: 'ask',

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { evaluateSkill } from './skill-evaluator';
 import { formatSystemMessage } from './suggest';
 import { sendNotification } from './notify';
 import { getYoloState, activateYolo, deactivateYolo, parseYoloCommand } from './yolo';
-import { DEFAULT_SESSION_GUIDANCE } from './defaults';
+import { buildDefaultSessionGuidance, DEFAULT_TEMP_SCRIPT_DIR } from './defaults';
 import type { HookInput, HookOutput, EvalResult, WardenConfig, Decision } from './types';
 
 // Note: rules.ts defaults to quiet mode, which is what we want in a
@@ -32,7 +32,8 @@ function emitDecision(decision: Decision, reason: string, stderrMessage?: string
 
 function handleSessionStart(config: WardenConfig): never {
   if (config.sessionGuidance === false) process.exit(0);
-  const text = config.sessionGuidance ?? DEFAULT_SESSION_GUIDANCE;
+  const text = config.sessionGuidance
+    ?? buildDefaultSessionGuidance(config.tempScriptDir ?? DEFAULT_TEMP_SCRIPT_DIR);
   const output: HookOutput = {
     hookSpecificOutput: {
       hookEventName: 'SessionStart',

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { evaluateSkill } from './skill-evaluator';
 import { formatSystemMessage } from './suggest';
 import { sendNotification } from './notify';
 import { getYoloState, activateYolo, deactivateYolo, parseYoloCommand } from './yolo';
+import { DEFAULT_SESSION_GUIDANCE } from './defaults';
 import type { HookInput, HookOutput, EvalResult, WardenConfig, Decision } from './types';
 
 // Note: rules.ts defaults to quiet mode, which is what we want in a
@@ -26,6 +27,19 @@ function emitDecision(decision: Decision, reason: string, stderrMessage?: string
     process.stderr.write(`${stderrMessage ?? reason}\n`);
     process.exit(2);
   }
+  process.exit(0);
+}
+
+function handleSessionStart(config: WardenConfig): never {
+  if (config.sessionGuidance === false) process.exit(0);
+  const text = config.sessionGuidance ?? DEFAULT_SESSION_GUIDANCE;
+  const output: HookOutput = {
+    hookSpecificOutput: {
+      hookEventName: 'SessionStart',
+      additionalContext: text,
+    },
+  };
+  process.stdout.write(JSON.stringify(output));
   process.exit(0);
 }
 
@@ -54,6 +68,11 @@ async function main() {
   } catch {
     // Can't parse input — don't interfere
     process.exit(0);
+  }
+
+  if (input.hook_event_name === 'SessionStart') {
+    const config = loadConfig(input.cwd);
+    handleSessionStart(config);
   }
 
   if (input.tool_name !== 'Bash' && input.tool_name !== 'Skill') {

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -343,6 +343,11 @@ function mergeNonLayerFields(config: WardenConfig, raw: Record<string, unknown>)
   } else if (raw.sessionGuidance !== undefined) {
     warn(`[warden] Warning: invalid sessionGuidance (expected string or false), ignoring\n`);
   }
+  if (typeof raw.tempScriptDir === 'string' && raw.tempScriptDir.length > 0) {
+    config.tempScriptDir = raw.tempScriptDir;
+  } else if (raw.tempScriptDir !== undefined) {
+    warn(`[warden] Warning: invalid tempScriptDir (expected non-empty string), ignoring\n`);
+  }
   // Skill-level defaultDecision from skills.defaultDecision
   if (raw.skills && typeof raw.skills === 'object') {
     const skills = raw.skills as Record<string, unknown>;

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -338,6 +338,11 @@ function mergeNonLayerFields(config: WardenConfig, raw: Record<string, unknown>)
   if (typeof raw.notifyOnDeny === 'boolean') {
     config.notifyOnDeny = raw.notifyOnDeny;
   }
+  if (typeof raw.sessionGuidance === 'string' || raw.sessionGuidance === false) {
+    config.sessionGuidance = raw.sessionGuidance;
+  } else if (raw.sessionGuidance !== undefined) {
+    warn(`[warden] Warning: invalid sessionGuidance (expected string or false), ignoring\n`);
+  }
   // Skill-level defaultDecision from skills.defaultDecision
   if (raw.skills && typeof raw.skills === 'object') {
     const skills = raw.skills as Record<string, unknown>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,13 @@ export interface WardenConfig {
   notifyOnAsk: boolean;
   notifyOnDeny: boolean;
   skillRules: SkillRulesConfig;
+  /**
+   * Text injected into every Claude Code session via the SessionStart hook.
+   * `string` — override the built-in guidance.
+   * `false` — disable injection entirely.
+   * `undefined` — use the built-in DEFAULT_SESSION_GUIDANCE.
+   */
+  sessionGuidance?: string | false;
 }
 
 export interface EvalResult {
@@ -137,23 +144,30 @@ export interface CommandEvalDetail {
 export interface HookInput {
   session_id: string;
   hook_event_name: string;
-  tool_name: string;
-  tool_input: { command?: string; [key: string]: unknown };
+  /** Present for PreToolUse; absent for SessionStart and other events. */
+  tool_name?: string;
+  /** Present for PreToolUse; absent for SessionStart. */
+  tool_input?: { command?: string; [key: string]: unknown };
   cwd: string;
-  permission_mode:
+  /** PreToolUse-only; not sent for SessionStart. */
+  permission_mode?:
     | 'default'
     | 'plan'
     | 'acceptEdits'
     | 'auto'
     | 'dontAsk'
     | 'bypassPermissions';
+  /** SessionStart-only: reason the session is (re)starting. */
+  source?: 'startup' | 'resume' | 'clear' | 'compact';
 }
 
 export interface HookOutput {
   hookSpecificOutput?: {
     hookEventName: string;
-    permissionDecision: Decision;
-    permissionDecisionReason: string;
+    permissionDecision?: Decision;
+    permissionDecisionReason?: string;
+    /** SessionStart: text appended to the session as a system message. */
+    additionalContext?: string;
   };
   systemMessage?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,9 +122,14 @@ export interface WardenConfig {
    * Text injected into every Claude Code session via the SessionStart hook.
    * `string` — override the built-in guidance.
    * `false` — disable injection entirely.
-   * `undefined` — use the built-in DEFAULT_SESSION_GUIDANCE.
+   * `undefined` — use the built-in guidance (interpolated with `tempScriptDir`).
    */
   sessionGuidance?: string | false;
+  /**
+   * Directory the built-in guidance tells Claude to save throwaway multi-line
+   * scripts to. Defaults to `/tmp`. Only used when `sessionGuidance` is unset.
+   */
+  tempScriptDir?: string;
 }
 
 export interface EvalResult {


### PR DESCRIPTION
## Summary
- Adds a SessionStart hook that injects short, pragmatic warden guidance as `additionalContext` into every Claude Code session — a proactive channel to complement the existing reactive ask/deny reasons.
- Optional `sessionGuidance` config field: `string` overrides the built-in text, `false` disables injection, unset uses `DEFAULT_SESSION_GUIDANCE`.
- Reuses the existing `dist/index.cjs` bundle by dispatching on `hook_event_name` before the `tool_name` gate; widens `HookInput` / `HookOutput` types to accommodate the SessionStart event shape.

Closes #96.

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm run build` produces updated `dist/index.cjs`
- [x] `pnpm run test` — 517/517 passing, including 6 new SessionStart tests (config loader + built-binary integration)
- [x] Manual stdin round-trip: SessionStart payload emits default guidance; PreToolUse `ls -la` still allows
- [ ] End-to-end: install plugin in a scratch repo, confirm guidance appears in `/context` on first session

🤖 Generated with [Claude Code](https://claude.com/claude-code)