### PR TITLE
chore: release v2.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "warden",
       "description": "Auto-approves safe commands, blocks dangerous ones, prompts for the rest",
-      "version": "2.5.3",
+      "version": "2.8.0",
       "author": {
         "name": "banyudu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Smart command safety filter for Claude Code — parses shell pipelines and evaluates per-command safety rules to auto-approve safe commands and block dangerous ones",
   "author": {
     "name": "banyudu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.8.0] - 2026-04-22
+
+### Features
+- default temp scripts to /tmp; add tempScriptDir config (5961909)
+- inject plugin-level guidance via SessionStart hook (#96) (33f09a1)
+
+### Other Changes
+- docs(release): consolidate into shared skill, drop duplicate command (200ed5d)
+- docs(release): align with hooks, protected main, and CI publishing (bb28db9)
+
 ## [2.4.0] - 2026-04-07
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-warden",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Smart command safety filter for Claude Code — auto-approves safe commands, blocks dangerous ones",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## [2.8.0] - 2026-04-22

### Features
- default temp scripts to /tmp; add tempScriptDir config (5961909)
- inject plugin-level guidance via SessionStart hook (#96) (33f09a1)

### Other Changes
- docs(release): consolidate into shared skill, drop duplicate command (200ed5d)
- docs(release): align with hooks, protected main, and CI publishing (bb28db9)