### PR TITLE
fix(ci): handle merge commits in auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,22 +10,23 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    if: "startsWith(github.event.head_commit.message, 'chore: release v')"
     steps:
       - uses: actions/checkout@v4
-      - name: Extract version from commit message
+      - name: Find release commit in push
         id: version
         env:
-          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          COMMITS_JSON: ${{ toJSON(github.event.commits) }}
         run: |
-          VERSION=$(echo "$COMMIT_MSG" | grep -oP 'v\d+\.\d+\.\d+')
+          VERSION=$(echo "$COMMITS_JSON" | jq -r '.[] | select(.message | startswith("chore: release v")) | .message' | head -n1 | grep -oP 'v\d+\.\d+\.\d+' || true)
           if [ -z "$VERSION" ]; then
-            echo "No version found in commit message"
-            exit 1
+            echo "No 'chore: release v<version>' commit in this push, skipping release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Extract changelog for this version
         id: changelog
+        if: steps.version.outputs.skip != 'true'
         env:
           VERSION_TAG: ${{ steps.version.outputs.version }}
         run: |
@@ -35,6 +36,7 @@ jobs:
           echo "$CHANGELOG" >> "$GITHUB_OUTPUT"
           echo "CHANGELOG_EOF" >> "$GITHUB_OUTPUT"
       - name: Create tag and release
+        if: steps.version.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
@@ -43,15 +45,3 @@ jobs:
           git tag "$VERSION"
           git push origin "$VERSION"
           gh release create "$VERSION" --title "$VERSION" --notes "$RELEASE_NOTES"
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-          registry-url: https://registry.npmjs.org
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm run test
-      - run: pnpm run build
-      - run: pnpm publish --access public --no-git-checks --provenance


### PR DESCRIPTION
## Summary

The auto-release workflow skipped on v2.8.0 because the release PR was merged as a merge commit — \`github.event.head_commit.message\` was \`Merge pull request #102...\`, not \`chore: release v2.8.0\`. The \`if: startsWith(...)\` job-level guard returned false and skipped the entire job.

### Changes

- Scan **all commits** in the push for a \`chore: release v<version>\` commit (via \`github.event.commits\`) instead of only checking the head commit. Merge-commit workflow now works.
- Gate downstream steps on a \`skip\` output when no release commit is found.
- Drop the duplicate \`pnpm publish\` step — \`publish.yml\` already handles npm publishing on \`release:published\` using the required \`npx -y npm@11.5.1\` path (trusted publisher OIDC rejects plain \`pnpm publish\`/older \`npm publish\` with a silent 404). Keeping both would also race.

### Recovery note

v2.8.0 was recovered manually: \`gh release create v2.8.0 --target main\` triggered \`publish.yml\`, which published to npm successfully.

## Test plan

- [ ] On next release PR merge, verify \`Auto Release\` workflow runs (not skipped) and tags + creates release
- [ ] Verify \`Publish to npm\` fires on the release and completes successfully