### PR TITLE
feat: educational reason strings for inline interpreter scripts

### DIFF
--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -18860,6 +18860,9 @@ function registryOpsPattern() {
     reason: "Registry modification"
   };
 }
+function inlineScriptReason(lang, ext) {
+  return `Inline ${lang} is hard to audit. For JSON, prefer \`jq\`. For reuse, save to scripts/*.${ext} and run it.`;
+}
 function pkgManagerRule(command, extraSafeCmds = []) {
   const safeCmds = [...SAFE_PKG_MANAGER_CMDS, ...extraSafeCmds];
   return {
@@ -19243,7 +19246,7 @@ var DEFAULT_CONFIG = {
         command: "node",
         default: "ask",
         argPatterns: [
-          { match: { anyArgMatches: ["^-e$", "^--eval", "^-p$", "^--print"] }, decision: "ask", reason: "Evaluating inline code" },
+          { match: { anyArgMatches: ["^-e$", "^--eval", "^-p$", "^--print"] }, decision: "ask", reason: inlineScriptReason("JavaScript", "js") },
           { match: { anyArgMatches: ["^--(version|help)$", "^-[vh]$"] }, decision: "allow", description: "Version/help flags" },
           { match: { noArgs: true }, decision: "ask", reason: "Interactive REPL" }
         ]
@@ -19272,6 +19275,7 @@ var DEFAULT_CONFIG = {
         command: cmd,
         default: "ask",
         argPatterns: [
+          { match: { anyArgMatches: ["^-c$"] }, decision: "ask", reason: inlineScriptReason("Python", "py") },
           { match: { anyArgMatches: ["^--(version|help)$", "^-V$"] }, decision: "allow" }
         ]
       })),
@@ -19430,14 +19434,18 @@ var DEFAULT_CONFIG = {
         argPatterns: [VERSION_HELP_FLAGS]
       })),
       // --- Scripting languages ---
-      ...["ruby", "perl", "php"].map((cmd) => ({
-        command: cmd,
-        default: "ask",
-        argPatterns: [
-          { match: { anyArgMatches: ["^-e$", "^--eval"] }, decision: "ask", reason: "Inline code execution" },
-          VERSION_HELP_FLAGS
-        ]
-      })),
+      { command: "ruby", default: "ask", argPatterns: [
+        { match: { anyArgMatches: ["^-e$", "^--eval"] }, decision: "ask", reason: inlineScriptReason("Ruby", "rb") },
+        VERSION_HELP_FLAGS
+      ] },
+      { command: "perl", default: "ask", argPatterns: [
+        { match: { anyArgMatches: ["^-e$", "^-E$"] }, decision: "ask", reason: inlineScriptReason("Perl", "pl") },
+        VERSION_HELP_FLAGS
+      ] },
+      { command: "php", default: "ask", argPatterns: [
+        { match: { anyArgMatches: ["^-r$"] }, decision: "ask", reason: inlineScriptReason("PHP", "php") },
+        VERSION_HELP_FLAGS
+      ] },
       // --- Java ecosystem ---
       { command: "java", default: "ask", argPatterns: [VERSION_HELP_FLAGS] },
       { command: "javac", default: "allow" },

--- a/dist/codex-export.cjs
+++ b/dist/codex-export.cjs
@@ -18864,6 +18864,9 @@ function registryOpsPattern() {
     reason: "Registry modification"
   };
 }
+function inlineScriptReason(lang, ext) {
+  return `Inline ${lang} is hard to audit. For JSON, prefer \`jq\`. For reuse, save to scripts/*.${ext} and run it.`;
+}
 function pkgManagerRule(command, extraSafeCmds = []) {
   const safeCmds = [...SAFE_PKG_MANAGER_CMDS, ...extraSafeCmds];
   return {
@@ -19247,7 +19250,7 @@ var DEFAULT_CONFIG = {
         command: "node",
         default: "ask",
         argPatterns: [
-          { match: { anyArgMatches: ["^-e$", "^--eval", "^-p$", "^--print"] }, decision: "ask", reason: "Evaluating inline code" },
+          { match: { anyArgMatches: ["^-e$", "^--eval", "^-p$", "^--print"] }, decision: "ask", reason: inlineScriptReason("JavaScript", "js") },
           { match: { anyArgMatches: ["^--(version|help)$", "^-[vh]$"] }, decision: "allow", description: "Version/help flags" },
           { match: { noArgs: true }, decision: "ask", reason: "Interactive REPL" }
         ]
@@ -19276,6 +19279,7 @@ var DEFAULT_CONFIG = {
         command: cmd,
         default: "ask",
         argPatterns: [
+          { match: { anyArgMatches: ["^-c$"] }, decision: "ask", reason: inlineScriptReason("Python", "py") },
           { match: { anyArgMatches: ["^--(version|help)$", "^-V$"] }, decision: "allow" }
         ]
       })),
@@ -19434,14 +19438,18 @@ var DEFAULT_CONFIG = {
         argPatterns: [VERSION_HELP_FLAGS]
       })),
       // --- Scripting languages ---
-      ...["ruby", "perl", "php"].map((cmd) => ({
-        command: cmd,
-        default: "ask",
-        argPatterns: [
-          { match: { anyArgMatches: ["^-e$", "^--eval"] }, decision: "ask", reason: "Inline code execution" },
-          VERSION_HELP_FLAGS
-        ]
-      })),
+      { command: "ruby", default: "ask", argPatterns: [
+        { match: { anyArgMatches: ["^-e$", "^--eval"] }, decision: "ask", reason: inlineScriptReason("Ruby", "rb") },
+        VERSION_HELP_FLAGS
+      ] },
+      { command: "perl", default: "ask", argPatterns: [
+        { match: { anyArgMatches: ["^-e$", "^-E$"] }, decision: "ask", reason: inlineScriptReason("Perl", "pl") },
+        VERSION_HELP_FLAGS
+      ] },
+      { command: "php", default: "ask", argPatterns: [
+        { match: { anyArgMatches: ["^-r$"] }, decision: "ask", reason: inlineScriptReason("PHP", "php") },
+        VERSION_HELP_FLAGS
+      ] },
       // --- Java ecosystem ---
       { command: "java", default: "ask", argPatterns: [VERSION_HELP_FLAGS] },
       { command: "javac", default: "allow" },

--- a/dist/copilot.cjs
+++ b/dist/copilot.cjs
@@ -18860,6 +18860,9 @@ function registryOpsPattern() {
     reason: "Registry modification"
   };
 }
+function inlineScriptReason(lang, ext) {
+  return `Inline ${lang} is hard to audit. For JSON, prefer \`jq\`. For reuse, save to scripts/*.${ext} and run it.`;
+}
 function pkgManagerRule(command, extraSafeCmds = []) {
   const safeCmds = [...SAFE_PKG_MANAGER_CMDS, ...extraSafeCmds];
   return {
@@ -19243,7 +19246,7 @@ var DEFAULT_CONFIG = {
         command: "node",
         default: "ask",
         argPatterns: [
-          { match: { anyArgMatches: ["^-e$", "^--eval", "^-p$", "^--print"] }, decision: "ask", reason: "Evaluating inline code" },
+          { match: { anyArgMatches: ["^-e$", "^--eval", "^-p$", "^--print"] }, decision: "ask", reason: inlineScriptReason("JavaScript", "js") },
           { match: { anyArgMatches: ["^--(version|help)$", "^-[vh]$"] }, decision: "allow", description: "Version/help flags" },
           { match: { noArgs: true }, decision: "ask", reason: "Interactive REPL" }
         ]
@@ -19272,6 +19275,7 @@ var DEFAULT_CONFIG = {
         command: cmd,
         default: "ask",
         argPatterns: [
+          { match: { anyArgMatches: ["^-c$"] }, decision: "ask", reason: inlineScriptReason("Python", "py") },
           { match: { anyArgMatches: ["^--(version|help)$", "^-V$"] }, decision: "allow" }
         ]
       })),
@@ -19430,14 +19434,18 @@ var DEFAULT_CONFIG = {
         argPatterns: [VERSION_HELP_FLAGS]
       })),
       // --- Scripting languages ---
-      ...["ruby", "perl", "php"].map((cmd) => ({
-        command: cmd,
-        default: "ask",
-        argPatterns: [
-          { match: { anyArgMatches: ["^-e$", "^--eval"] }, decision: "ask", reason: "Inline code execution" },
-          VERSION_HELP_FLAGS
-        ]
-      })),
+      { command: "ruby", default: "ask", argPatterns: [
+        { match: { anyArgMatches: ["^-e$", "^--eval"] }, decision: "ask", reason: inlineScriptReason("Ruby", "rb") },
+        VERSION_HELP_FLAGS
+      ] },
+      { command: "perl", default: "ask", argPatterns: [
+        { match: { anyArgMatches: ["^-e$", "^-E$"] }, decision: "ask", reason: inlineScriptReason("Perl", "pl") },
+        VERSION_HELP_FLAGS
+      ] },
+      { command: "php", default: "ask", argPatterns: [
+        { match: { anyArgMatches: ["^-r$"] }, decision: "ask", reason: inlineScriptReason("PHP", "php") },
+        VERSION_HELP_FLAGS
+      ] },
       // --- Java ecosystem ---
       { command: "java", default: "ask", argPatterns: [VERSION_HELP_FLAGS] },
       { command: "javac", default: "allow" },

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -18860,6 +18860,9 @@ function registryOpsPattern() {
     reason: "Registry modification"
   };
 }
+function inlineScriptReason(lang, ext) {
+  return `Inline ${lang} is hard to audit. For JSON, prefer \`jq\`. For reuse, save to scripts/*.${ext} and run it.`;
+}
 function pkgManagerRule(command, extraSafeCmds = []) {
   const safeCmds = [...SAFE_PKG_MANAGER_CMDS, ...extraSafeCmds];
   return {
@@ -19243,7 +19246,7 @@ var DEFAULT_CONFIG = {
         command: "node",
         default: "ask",
         argPatterns: [
-          { match: { anyArgMatches: ["^-e$", "^--eval", "^-p$", "^--print"] }, decision: "ask", reason: "Evaluating inline code" },
+          { match: { anyArgMatches: ["^-e$", "^--eval", "^-p$", "^--print"] }, decision: "ask", reason: inlineScriptReason("JavaScript", "js") },
           { match: { anyArgMatches: ["^--(version|help)$", "^-[vh]$"] }, decision: "allow", description: "Version/help flags" },
           { match: { noArgs: true }, decision: "ask", reason: "Interactive REPL" }
         ]
@@ -19272,6 +19275,7 @@ var DEFAULT_CONFIG = {
         command: cmd,
         default: "ask",
         argPatterns: [
+          { match: { anyArgMatches: ["^-c$"] }, decision: "ask", reason: inlineScriptReason("Python", "py") },
           { match: { anyArgMatches: ["^--(version|help)$", "^-V$"] }, decision: "allow" }
         ]
       })),
@@ -19430,14 +19434,18 @@ var DEFAULT_CONFIG = {
         argPatterns: [VERSION_HELP_FLAGS]
       })),
       // --- Scripting languages ---
-      ...["ruby", "perl", "php"].map((cmd) => ({
-        command: cmd,
-        default: "ask",
-        argPatterns: [
-          { match: { anyArgMatches: ["^-e$", "^--eval"] }, decision: "ask", reason: "Inline code execution" },
-          VERSION_HELP_FLAGS
-        ]
-      })),
+      { command: "ruby", default: "ask", argPatterns: [
+        { match: { anyArgMatches: ["^-e$", "^--eval"] }, decision: "ask", reason: inlineScriptReason("Ruby", "rb") },
+        VERSION_HELP_FLAGS
+      ] },
+      { command: "perl", default: "ask", argPatterns: [
+        { match: { anyArgMatches: ["^-e$", "^-E$"] }, decision: "ask", reason: inlineScriptReason("Perl", "pl") },
+        VERSION_HELP_FLAGS
+      ] },
+      { command: "php", default: "ask", argPatterns: [
+        { match: { anyArgMatches: ["^-r$"] }, decision: "ask", reason: inlineScriptReason("PHP", "php") },
+        VERSION_HELP_FLAGS
+      ] },
       // --- Java ecosystem ---
       { command: "java", default: "ask", argPatterns: [VERSION_HELP_FLAGS] },
       { command: "javac", default: "allow" },

--- a/src/__tests__/evaluator.test.ts
+++ b/src/__tests__/evaluator.test.ts
@@ -233,6 +233,35 @@ describe('evaluator', () => {
     });
   });
 
+  describe('inline interpreter reasons', () => {
+    it.each([
+      ['python -c "print(1)"',     'Python',     'py'],
+      ['python3 -c "print(1)"',    'Python',     'py'],
+      ['node -e "console.log(1)"', 'JavaScript', 'js'],
+      ['node --eval "1+1"',        'JavaScript', 'js'],
+      ['node -p "1+1"',            'JavaScript', 'js'],
+      ['perl -e "print 1"',        'Perl',       'pl'],
+      ['ruby -e "puts 1"',         'Ruby',       'rb'],
+      ['php -r "echo 1;"',         'PHP',        'php'],
+    ])('asks with educational reason for %s', (cmd, lang, ext) => {
+      const r = eval_(cmd);
+      expect(r.decision).toBe('ask');
+      expect(r.reason).toContain('jq');
+      expect(r.reason).toContain(`scripts/*.${ext}`);
+      expect(r.reason).toContain(lang);
+    });
+
+    it('does NOT trigger inline nudge for python3 script.py', () => {
+      const r = eval_('python3 script.py');
+      expect(r.reason ?? '').not.toContain('jq');
+    });
+
+    it('does NOT trigger inline nudge for node script.js', () => {
+      const r = eval_('node script.js');
+      expect(r.reason ?? '').not.toContain('jq');
+    });
+  });
+
   describe('edge cases', () => {
     it('allows empty command', () => {
       expect(eval_('').decision).toBe('allow');

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -61,6 +61,18 @@ function registryOpsPattern(): ArgPattern {
   };
 }
 
+function inlineScriptReason(lang: string, ext: string): string {
+  return `Inline ${lang} is hard to audit. For JSON, prefer \`jq\`. For reuse, save to scripts/*.${ext} and run it.`;
+}
+
+function inlineExecPattern(lang: string, ext: string, flags: string[]): ArgPattern {
+  return {
+    match: { anyArgMatches: flags },
+    decision: 'ask',
+    reason: inlineScriptReason(lang, ext),
+  };
+}
+
 function pkgManagerRule(command: string, extraSafeCmds: string[] = []): CommandRule {
   const safeCmds = [...SAFE_PKG_MANAGER_CMDS, ...extraSafeCmds];
   return {
@@ -290,7 +302,7 @@ export const DEFAULT_CONFIG: WardenConfig = {
         command: 'node',
         default: 'ask',
         argPatterns: [
-          { match: { anyArgMatches: ['^-e$', '^--eval', '^-p$', '^--print'] }, decision: 'ask', reason: 'Evaluating inline code' },
+          inlineExecPattern('JavaScript', 'js', ['^-e$', '^--eval', '^-p$', '^--print']),
           { match: { anyArgMatches: ['^--(version|help)$', '^-[vh]$'] }, decision: 'allow', description: 'Version/help flags' },
           { match: { noArgs: true }, decision: 'ask', reason: 'Interactive REPL' },
         ],
@@ -320,6 +332,7 @@ export const DEFAULT_CONFIG: WardenConfig = {
         command: cmd,
         default: 'ask',
         argPatterns: [
+          inlineExecPattern('Python', 'py', ['^-c$']),
           { match: { anyArgMatches: ['^--(version|help)$', '^-V$'] }, decision: 'allow' },
         ],
       })),
@@ -489,14 +502,9 @@ export const DEFAULT_CONFIG: WardenConfig = {
       })),
 
       // --- Scripting languages ---
-      ...['ruby', 'perl', 'php'].map((cmd): CommandRule => ({
-        command: cmd,
-        default: 'ask',
-        argPatterns: [
-          { match: { anyArgMatches: ['^-e$', '^--eval'] }, decision: 'ask', reason: 'Inline code execution' },
-          VERSION_HELP_FLAGS,
-        ],
-      })),
+      { command: 'ruby', default: 'ask', argPatterns: [inlineExecPattern('Ruby', 'rb', ['^-e$', '^--eval']), VERSION_HELP_FLAGS] },
+      { command: 'perl', default: 'ask', argPatterns: [inlineExecPattern('Perl', 'pl', ['^-e$', '^-E$']),   VERSION_HELP_FLAGS] },
+      { command: 'php',  default: 'ask', argPatterns: [inlineExecPattern('PHP',  'php', ['^-r$']),          VERSION_HELP_FLAGS] },
 
       // --- Java ecosystem ---
       { command: 'java', default: 'ask', argPatterns: [VERSION_HELP_FLAGS] },


### PR DESCRIPTION
## Summary
- Inline interpreter forms (`python -c`, `node -e`/`-p`/`--eval`, `ruby -e`, `perl -e`/`-E`, `php -r`) now emit educational `ask` reasons pointing Claude at `jq` for JSON and `scripts/*.<ext>` for reuse
- Reactive reasons survive SessionStart context compaction — the nudge fires at the exact moment Claude picks the wrong tool
- Non-inline forms (`python3 script.py`, `node script.js`) unaffected
- Drive-by fixes: PHP's inline flag corrected to `-r`, Perl gains `-E`

Fixes #98

## Test plan
- [x] New `inline interpreter reasons` test block covers all 8 flag variants plus two regression guards for non-inline forms
- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` — 530 tests pass
- [x] Manual hook probe confirms correct reason text for `python3 -c`, `node -e`, and that `python3 script.py` still returns the generic default