### PR TITLE
fix(ci): dispatch publish.yml from auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -45,3 +45,4 @@ jobs:
           git tag "$VERSION"
           git push origin "$VERSION"
           gh release create "$VERSION" --title "$VERSION" --notes "$RELEASE_NOTES"
+          gh workflow run publish.yml -f tag="$VERSION"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,12 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Git tag to publish (e.g. v2.9.0)
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -12,6 +18,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - uses: pnpm/action-setup@v4
         with:
           version: 10


### PR DESCRIPTION
## Summary
- Releases created by `auto-release.yml` use `GITHUB_TOKEN`, which does not trigger other workflows — so `publish.yml`'s `release: published` trigger never fired for `v2.8.1` and `v2.9.0`, and nothing got published to npm.
- Add `workflow_dispatch` (with a `tag` input) to `publish.yml` and check out that tag.
- `auto-release.yml` now calls `gh workflow run publish.yml -f tag="$VERSION"` right after `gh release create`. `workflow_dispatch` events *are* allowed to fire from `GITHUB_TOKEN`, so the publish job will actually run on every auto-release going forward.

## Test plan
- [ ] Merge, cut a new release via the usual `chore: release vX.Y.Z` flow, confirm the `Publish to npm` workflow runs and the version lands on npm.
- [ ] Backfill the missing versions manually: `gh workflow run publish.yml -f tag=v2.8.1` and `-f tag=v2.9.0` (or publish locally from the tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)