### PR TITLE
fix(parser): recursively evaluate explicit (...) subshells

### DIFF
--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -18280,7 +18280,6 @@ function walkNode(node, result) {
       break;
     }
     case "Subshell": {
-      result.hasSubshell = true;
       const subshell = node;
       if (subshell.list?.commands) {
         for (const cmd of subshell.list.commands) {
@@ -19519,7 +19518,18 @@ var DEFAULT_CONFIG = {
       })),
       // --- Scripting languages ---
       { command: "ruby", default: "ask", argPatterns: [...inlineExecPatterns("Ruby", ["^-e$", "^--eval"]), VERSION_HELP_FLAGS] },
-      { command: "perl", default: "ask", argPatterns: [...inlineExecPatterns("Perl", ["^-e$", "^-E$"]), VERSION_HELP_FLAGS] },
+      // `[npa]` bundles perl's common read-only short flags (`-pe`, `-ne`, `-ane`).
+      // `-i` (in-place edit) mutates files — detected separately so it's caught whether
+      // bundled (`-pie`, `-pi`) or passed as its own arg (`-i -pe`, `-i.bak -pe`).
+      {
+        command: "perl",
+        default: "ask",
+        argPatterns: [
+          { match: { anyArgMatches: ["^-[a-z]*i"] }, decision: "ask", reason: "Perl `-i` does in-place file edits. Save the script to scripts/*.pl and run it." },
+          ...inlineExecPatterns("Perl", ["^-[npa]*[eE]$"]),
+          VERSION_HELP_FLAGS
+        ]
+      },
       { command: "php", default: "ask", argPatterns: [...inlineExecPatterns("PHP", ["^-r$"]), VERSION_HELP_FLAGS] },
       // --- Java ecosystem ---
       { command: "java", default: "ask", argPatterns: [VERSION_HELP_FLAGS] },

--- a/dist/codex-export.cjs
+++ b/dist/codex-export.cjs
@@ -18284,7 +18284,6 @@ function walkNode(node, result) {
       break;
     }
     case "Subshell": {
-      result.hasSubshell = true;
       const subshell = node;
       if (subshell.list?.commands) {
         for (const cmd of subshell.list.commands) {
@@ -19523,7 +19522,18 @@ var DEFAULT_CONFIG = {
       })),
       // --- Scripting languages ---
       { command: "ruby", default: "ask", argPatterns: [...inlineExecPatterns("Ruby", ["^-e$", "^--eval"]), VERSION_HELP_FLAGS] },
-      { command: "perl", default: "ask", argPatterns: [...inlineExecPatterns("Perl", ["^-e$", "^-E$"]), VERSION_HELP_FLAGS] },
+      // `[npa]` bundles perl's common read-only short flags (`-pe`, `-ne`, `-ane`).
+      // `-i` (in-place edit) mutates files — detected separately so it's caught whether
+      // bundled (`-pie`, `-pi`) or passed as its own arg (`-i -pe`, `-i.bak -pe`).
+      {
+        command: "perl",
+        default: "ask",
+        argPatterns: [
+          { match: { anyArgMatches: ["^-[a-z]*i"] }, decision: "ask", reason: "Perl `-i` does in-place file edits. Save the script to scripts/*.pl and run it." },
+          ...inlineExecPatterns("Perl", ["^-[npa]*[eE]$"]),
+          VERSION_HELP_FLAGS
+        ]
+      },
       { command: "php", default: "ask", argPatterns: [...inlineExecPatterns("PHP", ["^-r$"]), VERSION_HELP_FLAGS] },
       // --- Java ecosystem ---
       { command: "java", default: "ask", argPatterns: [VERSION_HELP_FLAGS] },

--- a/dist/copilot.cjs
+++ b/dist/copilot.cjs
@@ -18280,7 +18280,6 @@ function walkNode(node, result) {
       break;
     }
     case "Subshell": {
-      result.hasSubshell = true;
       const subshell = node;
       if (subshell.list?.commands) {
         for (const cmd of subshell.list.commands) {
@@ -19519,7 +19518,18 @@ var DEFAULT_CONFIG = {
       })),
       // --- Scripting languages ---
       { command: "ruby", default: "ask", argPatterns: [...inlineExecPatterns("Ruby", ["^-e$", "^--eval"]), VERSION_HELP_FLAGS] },
-      { command: "perl", default: "ask", argPatterns: [...inlineExecPatterns("Perl", ["^-e$", "^-E$"]), VERSION_HELP_FLAGS] },
+      // `[npa]` bundles perl's common read-only short flags (`-pe`, `-ne`, `-ane`).
+      // `-i` (in-place edit) mutates files — detected separately so it's caught whether
+      // bundled (`-pie`, `-pi`) or passed as its own arg (`-i -pe`, `-i.bak -pe`).
+      {
+        command: "perl",
+        default: "ask",
+        argPatterns: [
+          { match: { anyArgMatches: ["^-[a-z]*i"] }, decision: "ask", reason: "Perl `-i` does in-place file edits. Save the script to scripts/*.pl and run it." },
+          ...inlineExecPatterns("Perl", ["^-[npa]*[eE]$"]),
+          VERSION_HELP_FLAGS
+        ]
+      },
       { command: "php", default: "ask", argPatterns: [...inlineExecPatterns("PHP", ["^-r$"]), VERSION_HELP_FLAGS] },
       // --- Java ecosystem ---
       { command: "java", default: "ask", argPatterns: [VERSION_HELP_FLAGS] },

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -18280,7 +18280,6 @@ function walkNode(node, result) {
       break;
     }
     case "Subshell": {
-      result.hasSubshell = true;
       const subshell = node;
       if (subshell.list?.commands) {
         for (const cmd of subshell.list.commands) {
@@ -19519,7 +19518,18 @@ var DEFAULT_CONFIG = {
       })),
       // --- Scripting languages ---
       { command: "ruby", default: "ask", argPatterns: [...inlineExecPatterns("Ruby", ["^-e$", "^--eval"]), VERSION_HELP_FLAGS] },
-      { command: "perl", default: "ask", argPatterns: [...inlineExecPatterns("Perl", ["^-e$", "^-E$"]), VERSION_HELP_FLAGS] },
+      // `[npa]` bundles perl's common read-only short flags (`-pe`, `-ne`, `-ane`).
+      // `-i` (in-place edit) mutates files — detected separately so it's caught whether
+      // bundled (`-pie`, `-pi`) or passed as its own arg (`-i -pe`, `-i.bak -pe`).
+      {
+        command: "perl",
+        default: "ask",
+        argPatterns: [
+          { match: { anyArgMatches: ["^-[a-z]*i"] }, decision: "ask", reason: "Perl `-i` does in-place file edits. Save the script to scripts/*.pl and run it." },
+          ...inlineExecPatterns("Perl", ["^-[npa]*[eE]$"]),
+          VERSION_HELP_FLAGS
+        ]
+      },
       { command: "php", default: "ask", argPatterns: [...inlineExecPatterns("PHP", ["^-r$"]), VERSION_HELP_FLAGS] },
       // --- Java ecosystem ---
       { command: "java", default: "ask", argPatterns: [VERSION_HELP_FLAGS] },
@@ -20913,11 +20923,12 @@ function generateAllowSnippet(details) {
   }
   return lines.join("\n");
 }
-function formatSystemMessage(decision, rawCommand, details) {
+function formatSystemMessage(decision, rawCommand, details, fallbackReason) {
   const relevant = details.filter((d) => d.decision !== "allow");
   if (decision === "ask") {
     const parts = relevant.map((d) => `\`${d.command}\`: ${d.reason}`);
-    const header = `[warden] ${parts.join(" | ")}`;
+    const body = parts.length > 0 ? parts.join(" | ") : fallbackReason || "";
+    const header = `[warden] ${body}`;
     const subcommandHints = relevant.filter((d) => d.args.length > 0).map((d) => {
       const sub = d.args[0];
       return `  Option A: Allow all \`${d.command}\` \u2192 \`/warden:allow ${d.command}\`
@@ -21191,14 +21202,14 @@ function emitResult(result, label, config) {
       const truncated = label.length > 80 ? label.slice(0, 77) + "..." : label;
       sendNotification("Claude Warden", `Blocked: ${truncated}`, config);
     }
-    const msg2 = formatSystemMessage("deny", label, result.details);
+    const msg2 = formatSystemMessage("deny", label, result.details, result.reason);
     emitDecision("deny", msg2, `[warden] Blocked: ${result.reason}`);
   }
   if (config.notifyOnAsk) {
     const truncated = label.length > 80 ? label.slice(0, 77) + "..." : label;
     sendNotification("Claude Warden", `Permission needed: ${truncated}`, config);
   }
-  const msg = formatSystemMessage("ask", label, result.details);
+  const msg = formatSystemMessage("ask", label, result.details, result.reason);
   emitDecision("ask", msg);
 }
 main().catch(() => process.exit(0));

--- a/src/__tests__/evaluator.test.ts
+++ b/src/__tests__/evaluator.test.ts
@@ -209,6 +209,22 @@ describe('evaluator', () => {
     it('asks for $(unknown-command)', () => {
       expect(eval_('echo $(unknown-sketchy-tool)').decision).toBe('ask');
     });
+
+    it('allows explicit (...) subshell when all inner commands are safe', () => {
+      expect(eval_('(cd /tmp && ls)').decision).toBe('allow');
+    });
+
+    it('allows explicit (...) subshell with pipes when all inner commands are safe', () => {
+      expect(eval_('(cd /tmp && echo hi | head -5)').decision).toBe('allow');
+    });
+
+    it('denies explicit (...) subshell containing a dangerous command', () => {
+      expect(eval_('(cd /tmp && sudo apt install foo)').decision).toBe('deny');
+    });
+
+    it('asks for explicit (...) subshell containing an unknown command', () => {
+      expect(eval_('(echo hi && unknown-sketchy-tool)').decision).toBe('ask');
+    });
   });
 
   describe('heredocs', () => {

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -148,9 +148,12 @@ describe('parseCommand', () => {
     expect(result.commands[1].command).toBe('echo');
   });
 
-  it('handles nested subshells', () => {
+  it('handles nested subshells — inner commands are extracted', () => {
     const result = parseCommand('(echo hello; (echo nested))');
-    expect(result.hasSubshell).toBe(true);
+    // Explicit (...) subshells have their contents walked into commands,
+    // so hasSubshell stays false — each command is evaluated normally.
+    expect(result.hasSubshell).toBe(false);
+    expect(result.commands.map(c => c.command)).toEqual(['echo', 'echo']);
   });
 
   it('detects command substitution in double quotes', () => {
@@ -275,7 +278,9 @@ describe('parseCommand', () => {
   it('does not affect actual subshell syntax', () => {
     const result = parseCommand('echo hello && (cd /tmp && ls)');
     expect(result.parseError).toBe(false);
-    expect(result.hasSubshell).toBe(true);
+    // Explicit (...) is walked through — inner commands are extracted.
+    expect(result.hasSubshell).toBe(false);
+    expect(result.commands.map(c => c.command)).toEqual(['echo', 'cd', 'ls']);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ function emitResult(result: EvalResult, label: string, config: WardenConfig): ne
       const truncated = label.length > 80 ? label.slice(0, 77) + '...' : label;
       sendNotification('Claude Warden', `Blocked: ${truncated}`, config);
     }
-    const msg = formatSystemMessage('deny', label, result.details);
+    const msg = formatSystemMessage('deny', label, result.details, result.reason);
     emitDecision('deny', msg, `[warden] Blocked: ${result.reason}`);
   }
 
@@ -161,7 +161,7 @@ function emitResult(result: EvalResult, label: string, config: WardenConfig): ne
     const truncated = label.length > 80 ? label.slice(0, 77) + '...' : label;
     sendNotification('Claude Warden', `Permission needed: ${truncated}`, config);
   }
-  const msg = formatSystemMessage('ask', label, result.details);
+  const msg = formatSystemMessage('ask', label, result.details, result.reason);
   emitDecision('ask', msg);
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -251,7 +251,10 @@ function walkNode(node: AstNode, result: WalkResult): void {
     }
 
     case 'Subshell': {
-      result.hasSubshell = true;
+      // Explicit `(...)` subshells: walk inner commands so they're evaluated
+      // normally. We don't set hasSubshell here — its contents are fully
+      // extracted and side-effects (cd, env) are scoped to the subshell,
+      // making them safer than top-level execution, not less safe.
       const subshell = node as SubshellNode;
       if (subshell.list?.commands) {
         for (const cmd of subshell.list.commands) {

--- a/src/suggest.ts
+++ b/src/suggest.ts
@@ -68,13 +68,15 @@ export function formatSystemMessage(
   decision: 'deny' | 'ask',
   rawCommand: string,
   details: CommandEvalDetail[],
+  fallbackReason?: string,
 ): string {
   const relevant = details.filter(d => d.decision !== 'allow');
 
   // Compact format for ask decisions
   if (decision === 'ask') {
     const parts = relevant.map(d => `\`${d.command}\`: ${d.reason}`);
-    const header = `[warden] ${parts.join(' | ')}`;
+    const body = parts.length > 0 ? parts.join(' | ') : (fallbackReason || '');
+    const header = `[warden] ${body}`;
 
     // Check if any flagged command has args that could be a sub-command
     const subcommandHints = relevant


### PR DESCRIPTION
## Summary

- Explicit `(...)` subshells previously tripped the `askOnSubshell` fallback even though their contents were fully extracted by the parser, producing prompts like `[warden]  —` with an empty reason.
- Walk inner commands into `commands` without setting `hasSubshell`. Side-effects in `(...)` are scoped to the subshell, making them safer than top-level execution — not less safe. Complex constructs (If/For/While/Case/Function) still set `hasSubshell` because their inner commands can't be extracted.
- `formatSystemMessage` now takes a `fallbackReason`, so ask/deny with empty `details` (parseError, recursion limit, complex constructs) surfaces the evaluator's reason instead of rendering `[warden]  —`.

## Before / After

`(cd apps/foo && bun run test | rg pass | tail -5)`
- before: `ask` with empty reason
- after: `allow` (each inner command evaluated individually)

`(cd /tmp && sudo apt install foo)` → `deny` (sudo caught by alwaysDeny)
`(echo hi && unknown-tool)` → `ask` (unknown-tool flagged)

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 561 passed
- [x] Verified original reported command now returns `allow` via the built hook
- [x] Added 4 evaluator tests covering safe/deny/ask cases inside explicit subshells
- [x] Updated 2 parser tests that asserted the old `hasSubshell=true` for `(...)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)