### PR TITLE
chore: release v2.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "warden",
       "description": "Auto-approves safe commands, blocks dangerous ones, prompts for the rest",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "author": {
         "name": "banyudu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "Smart command safety filter for Claude Code — parses shell pipelines and evaluates per-command safety rules to auto-approve safe commands and block dangerous ones",
   "author": {
     "name": "banyudu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.10.0] - 2026-04-24
+
+### Features
+- feat(defaults): allow perl bundled short-flags (-pe, -ne, -ane) while keeping -i safe (84a86b3)
+
+### Bug Fixes
+- fix(parser): recursively evaluate explicit (...) subshells instead of blanket ask (214fad7)
+- fix(ci): dispatch publish.yml from auto-release so npm publish actually runs (0c3ff27)
+
 ## [2.9.0] - 2026-04-23
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-warden",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "Smart command safety filter for Claude Code — auto-approves safe commands, blocks dangerous ones",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## [2.10.0] - 2026-04-24

### Features
- feat(defaults): allow perl bundled short-flags (-pe, -ne, -ane) while keeping -i safe (84a86b3)

### Bug Fixes
- fix(parser): recursively evaluate explicit (...) subshells instead of blanket ask (214fad7)
- fix(ci): dispatch publish.yml from auto-release so npm publish actually runs (0c3ff27)