### PR TITLE
fix(parser): recurse into for/while/if/case/function bodies

### DIFF
--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -18214,6 +18214,15 @@ function convertCommand(node) {
   const raw = rawParts.join(" ");
   return { command, originalCommand, args: args2, envPrefixes, raw };
 }
+function collectExpansionsFromWord(word, result) {
+  if (!word?.expansion) return;
+  for (const exp of word.expansion) {
+    if (exp.type === "CommandExpansion" && exp.command) {
+      result.hasSubshell = true;
+      result.subshellCommands.push(exp.command);
+    }
+  }
+}
 function collectCommandExpansions(node) {
   const commands = [];
   if (node.type === "Command") {
@@ -18288,15 +18297,70 @@ function walkNode(node, result) {
       }
       break;
     }
-    // Complex constructs — flag as subshell for safety
-    case "If":
-    case "For":
-    case "While":
-    case "Until":
-    case "Case":
-    case "Function":
-      result.hasSubshell = true;
+    // Control constructs: walk inner commands so each is evaluated normally.
+    // Like explicit (...) subshells, we don't set hasSubshell — the body is
+    // fully extracted into result.commands. Command substitutions inside the
+    // head expression (e.g. `for f in $(...)`) still flow into subshellCommands.
+    case "For": {
+      const f = node;
+      if (f.wordlist) {
+        for (const w of f.wordlist) collectExpansionsFromWord(w, result);
+      }
+      if (f.do?.commands) {
+        for (const cmd of f.do.commands) walkNode(cmd, result);
+      }
       break;
+    }
+    case "While":
+    case "Until": {
+      const w = node;
+      if (w.clause?.commands) {
+        for (const cmd of w.clause.commands) walkNode(cmd, result);
+      }
+      if (w.do?.commands) {
+        for (const cmd of w.do.commands) walkNode(cmd, result);
+      }
+      break;
+    }
+    case "If": {
+      const i = node;
+      if (i.clause?.commands) {
+        for (const cmd of i.clause.commands) walkNode(cmd, result);
+      }
+      if (i.then?.commands) {
+        for (const cmd of i.then.commands) walkNode(cmd, result);
+      }
+      if (i.else) {
+        if (i.else.type === "If") {
+          walkNode(i.else, result);
+        } else {
+          const elseList = i.else;
+          if (elseList.commands) {
+            for (const cmd of elseList.commands) walkNode(cmd, result);
+          }
+        }
+      }
+      break;
+    }
+    case "Case": {
+      const cs = node;
+      collectExpansionsFromWord(cs.clause, result);
+      if (cs.cases) {
+        for (const item of cs.cases) {
+          if (item.body?.commands) {
+            for (const cmd of item.body.commands) walkNode(cmd, result);
+          }
+        }
+      }
+      break;
+    }
+    case "Function": {
+      const fn2 = node;
+      if (fn2.body?.commands) {
+        for (const cmd of fn2.body.commands) walkNode(cmd, result);
+      }
+      break;
+    }
     default:
       break;
   }

--- a/dist/codex-export.cjs
+++ b/dist/codex-export.cjs
@@ -18218,6 +18218,15 @@ function convertCommand(node) {
   const raw = rawParts.join(" ");
   return { command, originalCommand, args: args2, envPrefixes, raw };
 }
+function collectExpansionsFromWord(word, result) {
+  if (!word?.expansion) return;
+  for (const exp of word.expansion) {
+    if (exp.type === "CommandExpansion" && exp.command) {
+      result.hasSubshell = true;
+      result.subshellCommands.push(exp.command);
+    }
+  }
+}
 function collectCommandExpansions(node) {
   const commands = [];
   if (node.type === "Command") {
@@ -18292,15 +18301,70 @@ function walkNode(node, result) {
       }
       break;
     }
-    // Complex constructs — flag as subshell for safety
-    case "If":
-    case "For":
-    case "While":
-    case "Until":
-    case "Case":
-    case "Function":
-      result.hasSubshell = true;
+    // Control constructs: walk inner commands so each is evaluated normally.
+    // Like explicit (...) subshells, we don't set hasSubshell — the body is
+    // fully extracted into result.commands. Command substitutions inside the
+    // head expression (e.g. `for f in $(...)`) still flow into subshellCommands.
+    case "For": {
+      const f = node;
+      if (f.wordlist) {
+        for (const w of f.wordlist) collectExpansionsFromWord(w, result);
+      }
+      if (f.do?.commands) {
+        for (const cmd of f.do.commands) walkNode(cmd, result);
+      }
       break;
+    }
+    case "While":
+    case "Until": {
+      const w = node;
+      if (w.clause?.commands) {
+        for (const cmd of w.clause.commands) walkNode(cmd, result);
+      }
+      if (w.do?.commands) {
+        for (const cmd of w.do.commands) walkNode(cmd, result);
+      }
+      break;
+    }
+    case "If": {
+      const i = node;
+      if (i.clause?.commands) {
+        for (const cmd of i.clause.commands) walkNode(cmd, result);
+      }
+      if (i.then?.commands) {
+        for (const cmd of i.then.commands) walkNode(cmd, result);
+      }
+      if (i.else) {
+        if (i.else.type === "If") {
+          walkNode(i.else, result);
+        } else {
+          const elseList = i.else;
+          if (elseList.commands) {
+            for (const cmd of elseList.commands) walkNode(cmd, result);
+          }
+        }
+      }
+      break;
+    }
+    case "Case": {
+      const cs = node;
+      collectExpansionsFromWord(cs.clause, result);
+      if (cs.cases) {
+        for (const item of cs.cases) {
+          if (item.body?.commands) {
+            for (const cmd of item.body.commands) walkNode(cmd, result);
+          }
+        }
+      }
+      break;
+    }
+    case "Function": {
+      const fn2 = node;
+      if (fn2.body?.commands) {
+        for (const cmd of fn2.body.commands) walkNode(cmd, result);
+      }
+      break;
+    }
     default:
       break;
   }

--- a/dist/copilot.cjs
+++ b/dist/copilot.cjs
@@ -18214,6 +18214,15 @@ function convertCommand(node) {
   const raw = rawParts.join(" ");
   return { command, originalCommand, args: args2, envPrefixes, raw };
 }
+function collectExpansionsFromWord(word, result) {
+  if (!word?.expansion) return;
+  for (const exp of word.expansion) {
+    if (exp.type === "CommandExpansion" && exp.command) {
+      result.hasSubshell = true;
+      result.subshellCommands.push(exp.command);
+    }
+  }
+}
 function collectCommandExpansions(node) {
   const commands = [];
   if (node.type === "Command") {
@@ -18288,15 +18297,70 @@ function walkNode(node, result) {
       }
       break;
     }
-    // Complex constructs — flag as subshell for safety
-    case "If":
-    case "For":
-    case "While":
-    case "Until":
-    case "Case":
-    case "Function":
-      result.hasSubshell = true;
+    // Control constructs: walk inner commands so each is evaluated normally.
+    // Like explicit (...) subshells, we don't set hasSubshell — the body is
+    // fully extracted into result.commands. Command substitutions inside the
+    // head expression (e.g. `for f in $(...)`) still flow into subshellCommands.
+    case "For": {
+      const f = node;
+      if (f.wordlist) {
+        for (const w of f.wordlist) collectExpansionsFromWord(w, result);
+      }
+      if (f.do?.commands) {
+        for (const cmd of f.do.commands) walkNode(cmd, result);
+      }
       break;
+    }
+    case "While":
+    case "Until": {
+      const w = node;
+      if (w.clause?.commands) {
+        for (const cmd of w.clause.commands) walkNode(cmd, result);
+      }
+      if (w.do?.commands) {
+        for (const cmd of w.do.commands) walkNode(cmd, result);
+      }
+      break;
+    }
+    case "If": {
+      const i = node;
+      if (i.clause?.commands) {
+        for (const cmd of i.clause.commands) walkNode(cmd, result);
+      }
+      if (i.then?.commands) {
+        for (const cmd of i.then.commands) walkNode(cmd, result);
+      }
+      if (i.else) {
+        if (i.else.type === "If") {
+          walkNode(i.else, result);
+        } else {
+          const elseList = i.else;
+          if (elseList.commands) {
+            for (const cmd of elseList.commands) walkNode(cmd, result);
+          }
+        }
+      }
+      break;
+    }
+    case "Case": {
+      const cs = node;
+      collectExpansionsFromWord(cs.clause, result);
+      if (cs.cases) {
+        for (const item of cs.cases) {
+          if (item.body?.commands) {
+            for (const cmd of item.body.commands) walkNode(cmd, result);
+          }
+        }
+      }
+      break;
+    }
+    case "Function": {
+      const fn2 = node;
+      if (fn2.body?.commands) {
+        for (const cmd of fn2.body.commands) walkNode(cmd, result);
+      }
+      break;
+    }
     default:
       break;
   }

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -18214,6 +18214,15 @@ function convertCommand(node) {
   const raw = rawParts.join(" ");
   return { command, originalCommand, args: args2, envPrefixes, raw };
 }
+function collectExpansionsFromWord(word, result) {
+  if (!word?.expansion) return;
+  for (const exp of word.expansion) {
+    if (exp.type === "CommandExpansion" && exp.command) {
+      result.hasSubshell = true;
+      result.subshellCommands.push(exp.command);
+    }
+  }
+}
 function collectCommandExpansions(node) {
   const commands = [];
   if (node.type === "Command") {
@@ -18288,15 +18297,70 @@ function walkNode(node, result) {
       }
       break;
     }
-    // Complex constructs — flag as subshell for safety
-    case "If":
-    case "For":
-    case "While":
-    case "Until":
-    case "Case":
-    case "Function":
-      result.hasSubshell = true;
+    // Control constructs: walk inner commands so each is evaluated normally.
+    // Like explicit (...) subshells, we don't set hasSubshell — the body is
+    // fully extracted into result.commands. Command substitutions inside the
+    // head expression (e.g. `for f in $(...)`) still flow into subshellCommands.
+    case "For": {
+      const f = node;
+      if (f.wordlist) {
+        for (const w of f.wordlist) collectExpansionsFromWord(w, result);
+      }
+      if (f.do?.commands) {
+        for (const cmd of f.do.commands) walkNode(cmd, result);
+      }
       break;
+    }
+    case "While":
+    case "Until": {
+      const w = node;
+      if (w.clause?.commands) {
+        for (const cmd of w.clause.commands) walkNode(cmd, result);
+      }
+      if (w.do?.commands) {
+        for (const cmd of w.do.commands) walkNode(cmd, result);
+      }
+      break;
+    }
+    case "If": {
+      const i = node;
+      if (i.clause?.commands) {
+        for (const cmd of i.clause.commands) walkNode(cmd, result);
+      }
+      if (i.then?.commands) {
+        for (const cmd of i.then.commands) walkNode(cmd, result);
+      }
+      if (i.else) {
+        if (i.else.type === "If") {
+          walkNode(i.else, result);
+        } else {
+          const elseList = i.else;
+          if (elseList.commands) {
+            for (const cmd of elseList.commands) walkNode(cmd, result);
+          }
+        }
+      }
+      break;
+    }
+    case "Case": {
+      const cs = node;
+      collectExpansionsFromWord(cs.clause, result);
+      if (cs.cases) {
+        for (const item of cs.cases) {
+          if (item.body?.commands) {
+            for (const cmd of item.body.commands) walkNode(cmd, result);
+          }
+        }
+      }
+      break;
+    }
+    case "Function": {
+      const fn2 = node;
+      if (fn2.body?.commands) {
+        for (const cmd of fn2.body.commands) walkNode(cmd, result);
+      }
+      break;
+    }
     default:
       break;
   }

--- a/src/__tests__/evaluator.test.ts
+++ b/src/__tests__/evaluator.test.ts
@@ -227,6 +227,51 @@ describe('evaluator', () => {
     });
   });
 
+  describe('control constructs', () => {
+    it('allows for-loop when body commands are safe', () => {
+      expect(eval_('for f in a b c; do echo $f; done').decision).toBe('allow');
+    });
+
+    it('allows while-loop when clause and body are safe', () => {
+      expect(eval_('while true; do ls; done').decision).toBe('allow');
+    });
+
+    it('allows until-loop when clause and body are safe', () => {
+      expect(eval_('until false; do echo hi; done').decision).toBe('allow');
+    });
+
+    it('allows if/then/else when all branches are safe', () => {
+      expect(eval_('if [ -f x ]; then cat x; else echo missing; fi').decision).toBe('allow');
+    });
+
+    it('allows case statement when each clause body is safe', () => {
+      expect(eval_('case $x in a) echo a;; *) echo other;; esac').decision).toBe('allow');
+    });
+
+    it('allows function definition with safe body', () => {
+      expect(eval_('foo() { echo hi; ls; }').decision).toBe('allow');
+    });
+
+    it('denies for-loop containing a dangerous command', () => {
+      expect(eval_('for f in *.txt; do sudo rm "$f"; done').decision).toBe('deny');
+    });
+
+    it('asks for-loop containing an unknown command', () => {
+      expect(eval_('for f in a b; do unknown-sketchy-tool "$f"; done').decision).toBe('ask');
+    });
+
+    it('allows for-loop with safe command substitution in wordlist (issue #115 repro)', () => {
+      const result = eval_(
+        'for f in $(rg --files . -g \'*.test.ts\' | head -10); do echo "=== $f ==="; bun test "$f" | tail -3; done',
+      );
+      expect(result.decision).toBe('allow');
+    });
+
+    it('denies for-loop with dangerous command substitution in wordlist', () => {
+      expect(eval_('for f in $(sudo rm -rf /); do echo "$f"; done').decision).toBe('deny');
+    });
+  });
+
   describe('heredocs', () => {
     it('allows cat with heredoc (body is data, not code)', () => {
       expect(eval_('cat <<EOF\nhello world\nEOF').decision).toBe('allow');

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -156,6 +156,73 @@ describe('parseCommand', () => {
     expect(result.commands.map(c => c.command)).toEqual(['echo', 'echo']);
   });
 
+  describe('control constructs — body commands extracted', () => {
+    it('extracts body of for loop with literal wordlist', () => {
+      const result = parseCommand('for f in a b c; do echo $f; done');
+      expect(result.parseError).toBe(false);
+      expect(result.hasSubshell).toBe(false);
+      expect(result.commands.map(c => c.command)).toEqual(['echo']);
+    });
+
+    it('extracts clause and body of while loop', () => {
+      const result = parseCommand('while true; do echo hi; done');
+      expect(result.parseError).toBe(false);
+      expect(result.hasSubshell).toBe(false);
+      expect(result.commands.map(c => c.command)).toEqual(['true', 'echo']);
+    });
+
+    it('extracts clause and body of until loop', () => {
+      const result = parseCommand('until false; do echo hi; done');
+      expect(result.parseError).toBe(false);
+      expect(result.hasSubshell).toBe(false);
+      expect(result.commands.map(c => c.command)).toEqual(['false', 'echo']);
+    });
+
+    it('extracts if/then/else branches', () => {
+      const result = parseCommand('if true; then echo yes; else echo no; fi');
+      expect(result.parseError).toBe(false);
+      expect(result.hasSubshell).toBe(false);
+      expect(result.commands.map(c => c.command)).toEqual(['true', 'echo', 'echo']);
+    });
+
+    it('extracts elif chains via nested If in else', () => {
+      const result = parseCommand('if [ -f x ]; then echo a; elif [ -f y ]; then echo b; else echo c; fi');
+      expect(result.parseError).toBe(false);
+      expect(result.hasSubshell).toBe(false);
+      expect(result.commands.map(c => c.command)).toEqual(['[', 'echo', '[', 'echo', 'echo']);
+    });
+
+    it('extracts each clause body of case statement', () => {
+      const result = parseCommand('case $x in a) echo a;; b|c) echo bc;; *) echo other;; esac');
+      expect(result.parseError).toBe(false);
+      expect(result.hasSubshell).toBe(false);
+      expect(result.commands.map(c => c.command)).toEqual(['echo', 'echo', 'echo']);
+    });
+
+    it('extracts function body', () => {
+      const result = parseCommand('foo() { echo hi; ls; }');
+      expect(result.parseError).toBe(false);
+      expect(result.hasSubshell).toBe(false);
+      expect(result.commands.map(c => c.command)).toEqual(['echo', 'ls']);
+    });
+
+    it('captures command substitutions inside for-loop wordlist as subshellCommands', () => {
+      const result = parseCommand('for f in $(rg --files .); do echo "$f"; done');
+      expect(result.parseError).toBe(false);
+      expect(result.hasSubshell).toBe(true);
+      expect(result.subshellCommands).toEqual(['rg --files .']);
+      expect(result.commands.map(c => c.command)).toEqual(['echo']);
+    });
+
+    it('captures command substitutions inside case discriminant', () => {
+      const result = parseCommand('case $(uname) in Linux) echo lin;; *) echo other;; esac');
+      expect(result.parseError).toBe(false);
+      expect(result.hasSubshell).toBe(true);
+      expect(result.subshellCommands).toEqual(['uname']);
+      expect(result.commands.map(c => c.command)).toEqual(['echo', 'echo']);
+    });
+  });
+
   it('detects command substitution in double quotes', () => {
     const result = parseCommand('echo "today is $(date)"');
     expect(result.hasSubshell).toBe(true);

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -42,9 +42,50 @@ interface LogicalExpressionNode extends AstNode {
   right: AstNode;
 }
 
+interface CompoundList {
+  type: 'CompoundList';
+  commands: AstNode[];
+}
+
 interface SubshellNode extends AstNode {
   type: 'Subshell';
-  list: { type: 'CompoundList'; commands: AstNode[] };
+  list: CompoundList;
+}
+
+interface ForNode extends AstNode {
+  type: 'For';
+  wordlist?: WordNode[];
+  do?: CompoundList;
+}
+
+interface WhileUntilNode extends AstNode {
+  type: 'While' | 'Until';
+  clause?: CompoundList;
+  do?: CompoundList;
+}
+
+interface IfNode extends AstNode {
+  type: 'If';
+  clause?: CompoundList;
+  then?: CompoundList;
+  else?: CompoundList | IfNode;
+}
+
+interface CaseItemNode {
+  type: 'CaseItem';
+  pattern?: WordNode[];
+  body?: CompoundList;
+}
+
+interface CaseNode extends AstNode {
+  type: 'Case';
+  clause?: WordNode;
+  cases?: CaseItemNode[];
+}
+
+interface FunctionNode extends AstNode {
+  type: 'Function';
+  body?: CompoundList;
 }
 
 interface ScriptNode extends AstNode {
@@ -170,6 +211,21 @@ function convertCommand(node: CommandNode): ParsedCommand | null {
   return { command, originalCommand, args, envPrefixes, raw };
 }
 
+function collectExpansionsFromWord(word: WordNode | undefined, result: WalkResult): void {
+  if (!word?.expansion) return;
+  for (const exp of word.expansion) {
+    if (exp.type === 'CommandExpansion' && exp.command) {
+      result.hasSubshell = true;
+      result.subshellCommands.push(exp.command);
+    }
+  }
+}
+
+function walkCompoundList(list: CompoundList | undefined, result: WalkResult): void {
+  if (!list?.commands) return;
+  for (const cmd of list.commands) walkNode(cmd, result);
+}
+
 function collectCommandExpansions(node: AstNode): string[] {
   const commands: string[] = [];
 
@@ -264,15 +320,51 @@ function walkNode(node: AstNode, result: WalkResult): void {
       break;
     }
 
-    // Complex constructs — flag as subshell for safety
-    case 'If':
-    case 'For':
-    case 'While':
-    case 'Until':
-    case 'Case':
-    case 'Function':
-      result.hasSubshell = true;
+    // Control constructs mirror the Subshell handler above: their bodies are
+    // walked into result.commands so each inner command is evaluated normally.
+    // hasSubshell stays false unless a head expression (`for f in $(...)`,
+    // `case $(...) in ...`) introduces a real command substitution.
+    case 'For': {
+      const f = node as ForNode;
+      if (f.wordlist) {
+        for (const w of f.wordlist) collectExpansionsFromWord(w, result);
+      }
+      walkCompoundList(f.do, result);
       break;
+    }
+
+    case 'While':
+    case 'Until': {
+      const w = node as WhileUntilNode;
+      walkCompoundList(w.clause, result);
+      walkCompoundList(w.do, result);
+      break;
+    }
+
+    case 'If': {
+      const i = node as IfNode;
+      walkCompoundList(i.clause, result);
+      walkCompoundList(i.then, result);
+      if (i.else) {
+        if (i.else.type === 'If') walkNode(i.else, result);
+        else walkCompoundList(i.else, result);
+      }
+      break;
+    }
+
+    case 'Case': {
+      const cs = node as CaseNode;
+      collectExpansionsFromWord(cs.clause, result);
+      if (cs.cases) {
+        for (const item of cs.cases) walkCompoundList(item.body, result);
+      }
+      break;
+    }
+
+    case 'Function': {
+      walkCompoundList((node as FunctionNode).body, result);
+      break;
+    }
 
     default:
       break;


### PR DESCRIPTION
## Summary
- Replace opaque `If/For/While/Until/Case/Function` handling in `walkNode` with recursive walks into their bodies, mirroring the existing explicit `(...)` subshell handler — body commands now flow through normal per-command evaluation.
- Capture command substitutions inside for-wordlist and case-discriminant via a new `collectExpansionsFromWord` helper so `for f in $(...)` still flags `subshellCommands` correctly.
- Add a small `walkCompoundList` helper to keep the new switch arms tidy; type `IfNode.else` as `CompoundList | IfNode` so elif chains need no casts.

Closes #115.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` — 580/580 passing (9 new parser tests, 10 new evaluator tests)
- [x] Issue #115 repro via `pnpm run eval` returns `permissionDecision: "allow"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)