### PR TITLE
chore: release v2.10.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "warden",
       "description": "Auto-approves safe commands, blocks dangerous ones, prompts for the rest",
-      "version": "2.10.1",
+      "version": "2.10.2",
       "author": {
         "name": "banyudu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "Smart command safety filter for Claude Code — parses shell pipelines and evaluates per-command safety rules to auto-approve safe commands and block dangerous ones",
   "author": {
     "name": "banyudu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.10.2] - 2026-05-07
+
+### Bug Fixes
+- fix(parser): bump bash-parser to 0.6.0 for process substitution (23c3e5a)
+
 ## [2.10.1] - 2026-04-29
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-warden",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "Smart command safety filter for Claude Code — auto-approves safe commands, blocks dangerous ones",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## [2.10.2] - 2026-05-07

### Bug Fixes
- fix(parser): bump bash-parser to 0.6.0 for process substitution (23c3e5a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)