### PR TITLE
chore: release v2.10.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "warden",
       "description": "Auto-approves safe commands, blocks dangerous ones, prompts for the rest",
-      "version": "2.10.2",
+      "version": "2.10.3",
       "author": {
         "name": "banyudu"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "warden",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "description": "Smart command safety filter for Claude Code — parses shell pipelines and evaluates per-command safety rules to auto-approve safe commands and block dangerous ones",
   "author": {
     "name": "banyudu"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.10.3] - 2026-05-18
+
+### Features
+- feat(defaults): allow read-only `composio` CLI subcommands and `execute` with read verbs (GET/LIST/SEARCH/FETCH/READ/COUNT/RETRIEVE/FIND/VIEW/SHOW/DESCRIBE/CHECK), plus `--get-schema` / `--dry-run` flags and `COMPOSIO_SEARCH_TOOLS` discovery; mutating slugs and `link`/`listen`/`proxy`/`run` still ask
+
 ## [2.10.2] - 2026-05-07
 
 ### Bug Fixes

--- a/dist/cli.cjs
+++ b/dist/cli.cjs
@@ -19714,6 +19714,18 @@ var DEFAULT_CONFIG = {
         { match: { anyArgMatches: ["^(describe|list|get|search|lookup|check)-[a-z][a-z0-9-]*$"] }, decision: "allow", description: "Read-only verb-noun" },
         VERSION_HELP_FLAGS
       ] },
+      // --- Composio CLI ---
+      // Auth is persistent in ~/.composio/, so most discovery/inspection is safe.
+      // `execute` is allowed only for slugs whose verb matches a read pattern
+      // (GET/LIST/SEARCH/FETCH/READ/COUNT/RETRIEVE/FIND/VIEW/SHOW/DESCRIBE/CHECK).
+      // Everything else (link, listen, proxy, run, mutating execute) falls through to ask.
+      { command: "composio", default: "ask", argPatterns: [
+        { match: { anyArgMatches: ["^(search|whoami|apps|connections|triggers|list|ls|tools|dev)$"] }, decision: "allow", description: "Read-only composio subcommands" },
+        { match: { anyArgMatches: ["^--(get-schema|dry-run)$"] }, decision: "allow", description: "Schema inspection / dry-run flags" },
+        { match: { argsMatch: ["^execute\\s+([A-Z0-9]+_)*(GET|LIST|SEARCH|FETCH|READ|COUNT|RETRIEVE|FIND|VIEW|SHOW|DESCRIBE|CHECK)(_[A-Z0-9_]+)?(\\s|$)"] }, decision: "allow", description: "Read-only execute (GET/LIST/SEARCH/...)" },
+        { match: { argsMatch: ["^execute\\s+\\S*COMPOSIO_SEARCH_TOOLS\\b"] }, decision: "allow", description: "Tool discovery slug" },
+        VERSION_HELP_FLAGS
+      ] },
       // --- Helm ---
       { command: "helm", default: "ask", argPatterns: [
         { match: { anyArgMatches: ["^(list|search|show|status|get|template|version|env|history)$"] }, decision: "allow", description: "Read-only helm commands" },

--- a/dist/codex-export.cjs
+++ b/dist/codex-export.cjs
@@ -19718,6 +19718,18 @@ var DEFAULT_CONFIG = {
         { match: { anyArgMatches: ["^(describe|list|get|search|lookup|check)-[a-z][a-z0-9-]*$"] }, decision: "allow", description: "Read-only verb-noun" },
         VERSION_HELP_FLAGS
       ] },
+      // --- Composio CLI ---
+      // Auth is persistent in ~/.composio/, so most discovery/inspection is safe.
+      // `execute` is allowed only for slugs whose verb matches a read pattern
+      // (GET/LIST/SEARCH/FETCH/READ/COUNT/RETRIEVE/FIND/VIEW/SHOW/DESCRIBE/CHECK).
+      // Everything else (link, listen, proxy, run, mutating execute) falls through to ask.
+      { command: "composio", default: "ask", argPatterns: [
+        { match: { anyArgMatches: ["^(search|whoami|apps|connections|triggers|list|ls|tools|dev)$"] }, decision: "allow", description: "Read-only composio subcommands" },
+        { match: { anyArgMatches: ["^--(get-schema|dry-run)$"] }, decision: "allow", description: "Schema inspection / dry-run flags" },
+        { match: { argsMatch: ["^execute\\s+([A-Z0-9]+_)*(GET|LIST|SEARCH|FETCH|READ|COUNT|RETRIEVE|FIND|VIEW|SHOW|DESCRIBE|CHECK)(_[A-Z0-9_]+)?(\\s|$)"] }, decision: "allow", description: "Read-only execute (GET/LIST/SEARCH/...)" },
+        { match: { argsMatch: ["^execute\\s+\\S*COMPOSIO_SEARCH_TOOLS\\b"] }, decision: "allow", description: "Tool discovery slug" },
+        VERSION_HELP_FLAGS
+      ] },
       // --- Helm ---
       { command: "helm", default: "ask", argPatterns: [
         { match: { anyArgMatches: ["^(list|search|show|status|get|template|version|env|history)$"] }, decision: "allow", description: "Read-only helm commands" },

--- a/dist/copilot.cjs
+++ b/dist/copilot.cjs
@@ -19714,6 +19714,18 @@ var DEFAULT_CONFIG = {
         { match: { anyArgMatches: ["^(describe|list|get|search|lookup|check)-[a-z][a-z0-9-]*$"] }, decision: "allow", description: "Read-only verb-noun" },
         VERSION_HELP_FLAGS
       ] },
+      // --- Composio CLI ---
+      // Auth is persistent in ~/.composio/, so most discovery/inspection is safe.
+      // `execute` is allowed only for slugs whose verb matches a read pattern
+      // (GET/LIST/SEARCH/FETCH/READ/COUNT/RETRIEVE/FIND/VIEW/SHOW/DESCRIBE/CHECK).
+      // Everything else (link, listen, proxy, run, mutating execute) falls through to ask.
+      { command: "composio", default: "ask", argPatterns: [
+        { match: { anyArgMatches: ["^(search|whoami|apps|connections|triggers|list|ls|tools|dev)$"] }, decision: "allow", description: "Read-only composio subcommands" },
+        { match: { anyArgMatches: ["^--(get-schema|dry-run)$"] }, decision: "allow", description: "Schema inspection / dry-run flags" },
+        { match: { argsMatch: ["^execute\\s+([A-Z0-9]+_)*(GET|LIST|SEARCH|FETCH|READ|COUNT|RETRIEVE|FIND|VIEW|SHOW|DESCRIBE|CHECK)(_[A-Z0-9_]+)?(\\s|$)"] }, decision: "allow", description: "Read-only execute (GET/LIST/SEARCH/...)" },
+        { match: { argsMatch: ["^execute\\s+\\S*COMPOSIO_SEARCH_TOOLS\\b"] }, decision: "allow", description: "Tool discovery slug" },
+        VERSION_HELP_FLAGS
+      ] },
       // --- Helm ---
       { command: "helm", default: "ask", argPatterns: [
         { match: { anyArgMatches: ["^(list|search|show|status|get|template|version|env|history)$"] }, decision: "allow", description: "Read-only helm commands" },

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -19714,6 +19714,18 @@ var DEFAULT_CONFIG = {
         { match: { anyArgMatches: ["^(describe|list|get|search|lookup|check)-[a-z][a-z0-9-]*$"] }, decision: "allow", description: "Read-only verb-noun" },
         VERSION_HELP_FLAGS
       ] },
+      // --- Composio CLI ---
+      // Auth is persistent in ~/.composio/, so most discovery/inspection is safe.
+      // `execute` is allowed only for slugs whose verb matches a read pattern
+      // (GET/LIST/SEARCH/FETCH/READ/COUNT/RETRIEVE/FIND/VIEW/SHOW/DESCRIBE/CHECK).
+      // Everything else (link, listen, proxy, run, mutating execute) falls through to ask.
+      { command: "composio", default: "ask", argPatterns: [
+        { match: { anyArgMatches: ["^(search|whoami|apps|connections|triggers|list|ls|tools|dev)$"] }, decision: "allow", description: "Read-only composio subcommands" },
+        { match: { anyArgMatches: ["^--(get-schema|dry-run)$"] }, decision: "allow", description: "Schema inspection / dry-run flags" },
+        { match: { argsMatch: ["^execute\\s+([A-Z0-9]+_)*(GET|LIST|SEARCH|FETCH|READ|COUNT|RETRIEVE|FIND|VIEW|SHOW|DESCRIBE|CHECK)(_[A-Z0-9_]+)?(\\s|$)"] }, decision: "allow", description: "Read-only execute (GET/LIST/SEARCH/...)" },
+        { match: { argsMatch: ["^execute\\s+\\S*COMPOSIO_SEARCH_TOOLS\\b"] }, decision: "allow", description: "Tool discovery slug" },
+        VERSION_HELP_FLAGS
+      ] },
       // --- Helm ---
       { command: "helm", default: "ask", argPatterns: [
         { match: { anyArgMatches: ["^(list|search|show|status|get|template|version|env|history)$"] }, decision: "allow", description: "Read-only helm commands" },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-warden",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "description": "Smart command safety filter for Claude Code — auto-approves safe commands, blocks dangerous ones",
   "type": "module",
   "main": "dist/index.cjs",

--- a/src/__tests__/evaluator.test.ts
+++ b/src/__tests__/evaluator.test.ts
@@ -1262,4 +1262,74 @@ describe('evaluator', () => {
       expect(evalWith('fly ssh console -a my-app -C "bash"', { trustedRemotes: toRemotes(apps, 'fly') }).decision).toBe('allow');
     });
   });
+
+  describe('composio', () => {
+    it('allows composio --help', () => {
+      expect(eval_('composio --help').decision).toBe('allow');
+    });
+
+    it('allows composio whoami', () => {
+      expect(eval_('composio whoami').decision).toBe('allow');
+    });
+
+    it('allows composio search "linear issues"', () => {
+      expect(eval_('composio search "linear issues"').decision).toBe('allow');
+    });
+
+    it('allows execute with GET slug', () => {
+      expect(eval_('composio execute LINEAR_GET_LINEAR_ISSUE -d {"issue_id":"ENG-1"}').decision).toBe('allow');
+    });
+
+    it('allows execute with LIST slug', () => {
+      expect(eval_('composio execute SLACK_LIST_ALL_CHANNELS').decision).toBe('allow');
+    });
+
+    it('allows execute with FETCH slug', () => {
+      expect(eval_('composio execute GMAIL_FETCH_EMAILS').decision).toBe('allow');
+    });
+
+    it('allows execute with SEARCH slug', () => {
+      expect(eval_('composio execute LINEAR_SEARCH_ISSUES').decision).toBe('allow');
+    });
+
+    it('allows COMPOSIO_SEARCH_TOOLS discovery', () => {
+      expect(eval_('composio execute COMPOSIO_SEARCH_TOOLS -d {}').decision).toBe('allow');
+    });
+
+    it('allows --get-schema inspection', () => {
+      expect(eval_('composio execute LINEAR_CREATE_ISSUE --get-schema').decision).toBe('allow');
+    });
+
+    it('allows --dry-run', () => {
+      expect(eval_('composio execute LINEAR_CREATE_ISSUE --dry-run -d {}').decision).toBe('allow');
+    });
+
+    it('asks for execute with CREATE slug', () => {
+      expect(eval_('composio execute LINEAR_CREATE_ISSUE -d {}').decision).toBe('ask');
+    });
+
+    it('asks for execute with SEND slug', () => {
+      expect(eval_('composio execute SLACK_SEND_MESSAGE -d {}').decision).toBe('ask');
+    });
+
+    it('asks for execute with DELETE slug', () => {
+      expect(eval_('composio execute LINEAR_DELETE_ISSUE -d {}').decision).toBe('ask');
+    });
+
+    it('asks for execute with UPDATE slug', () => {
+      expect(eval_('composio execute LINEAR_UPDATE_AN_EXISTING_ISSUE -d {}').decision).toBe('ask');
+    });
+
+    it('asks for composio link', () => {
+      expect(eval_('composio link slack').decision).toBe('ask');
+    });
+
+    it('asks for composio listen', () => {
+      expect(eval_('composio listen').decision).toBe('ask');
+    });
+
+    it('asks for composio proxy', () => {
+      expect(eval_('composio proxy GET /v1/me --toolkit github').decision).toBe('ask');
+    });
+  });
 });

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -649,6 +649,19 @@ export const DEFAULT_CONFIG: WardenConfig = {
         VERSION_HELP_FLAGS,
       ]},
 
+      // --- Composio CLI ---
+      // Auth is persistent in ~/.composio/, so most discovery/inspection is safe.
+      // `execute` is allowed only for slugs whose verb matches a read pattern
+      // (GET/LIST/SEARCH/FETCH/READ/COUNT/RETRIEVE/FIND/VIEW/SHOW/DESCRIBE/CHECK).
+      // Everything else (link, listen, proxy, run, mutating execute) falls through to ask.
+      { command: 'composio', default: 'ask', argPatterns: [
+        { match: { anyArgMatches: ['^(search|whoami|apps|connections|triggers|list|ls|tools|dev)$'] }, decision: 'allow', description: 'Read-only composio subcommands' },
+        { match: { anyArgMatches: ['^--(get-schema|dry-run)$'] }, decision: 'allow', description: 'Schema inspection / dry-run flags' },
+        { match: { argsMatch: ['^execute\\s+([A-Z0-9]+_)*(GET|LIST|SEARCH|FETCH|READ|COUNT|RETRIEVE|FIND|VIEW|SHOW|DESCRIBE|CHECK)(_[A-Z0-9_]+)?(\\s|$)'] }, decision: 'allow', description: 'Read-only execute (GET/LIST/SEARCH/...)' },
+        { match: { argsMatch: ['^execute\\s+\\S*COMPOSIO_SEARCH_TOOLS\\b'] }, decision: 'allow', description: 'Tool discovery slug' },
+        VERSION_HELP_FLAGS,
+      ]},
+
       // --- Helm ---
       { command: 'helm', default: 'ask', argPatterns: [
         { match: { anyArgMatches: ['^(list|search|show|status|get|template|version|env|history)$'] }, decision: 'allow', description: 'Read-only helm commands' },


### PR DESCRIPTION
## [2.10.3] - 2026-05-18

### Features
- feat(defaults): allow read-only `composio` CLI subcommands and `execute` with read verbs (GET/LIST/SEARCH/FETCH/READ/COUNT/RETRIEVE/FIND/VIEW/SHOW/DESCRIBE/CHECK), plus `--get-schema` / `--dry-run` flags and `COMPOSIO_SEARCH_TOOLS` discovery; mutating slugs and `link`/`listen`/`proxy`/`run` still ask

🤖 Generated with [Claude Code](https://claude.com/claude-code)